### PR TITLE
WiFi: Add ability to set MAC address

### DIFF
--- a/src/board_preference.cpp
+++ b/src/board_preference.cpp
@@ -32,6 +32,7 @@ bool BoardPreference::clear() {
   _board_host_name = "";
   _board_location = "";
   _board_room = "";
+  _spoofed_mac_addr = "";
   return write_preferences();
 }
 
@@ -92,12 +93,20 @@ bool BoardPreference::read_preferences() {
   Log.traceln("BoardPreference::read_preferences: _available_sensors_bytes: 0x" + String(_available_sensors_bytes, HEX));
   _board_host_name = EEPROM.readString(addr);
   addr += _board_host_name.length() + 1;
-  Log.traceln("BoardPreference::read_preferences: _board_host_name: '" + _board_host_name + "'");
+  Log.traceln("BoardPreference::read_preferences: _board_host_name: '"
+              + _board_host_name + "'");
   _board_location = EEPROM.readString(addr);
   addr += _board_location.length() + 1;
-  Log.traceln("BoardPreference::read_preferences: _board_location: '" + _board_location + "'");
+  Log.traceln("BoardPreference::read_preferences: _board_location: '"
+              + _board_location + "'");
   _board_room = EEPROM.readString(addr);
-  Log.traceln("BoardPreference::read_preferences: _board_room: '" + _board_room + "'");
+  addr += _board_room.length() + 1;
+  Log.traceln("BoardPreference::read_preferences: _board_room: '"
+              + _board_room + "'");
+  _spoofed_mac_addr = EEPROM.readString(addr);
+  addr += _spoofed_mac_addr.length() + 1;
+  Log.traceln("BoardPreference::read_preferences: _spoofed_mac_addr: '"
+              + _spoofed_mac_addr + "'");
 
   return true;
 }
@@ -107,7 +116,8 @@ bool BoardPreference::write_preferences() {
   Log.traceln("BoardPreference::write_preferences: _available_sensors_bytes: '0x" + String(_available_sensors_bytes, HEX) + "', "
               + "_board_host_name: '" + _board_host_name + "', "
               + "_board_location: '" + _board_location + "', "
-              + "_board_room: '" + _board_room + "'");
+              + "_board_room: '" + _board_room + "'"
+              + "_spoofed_mac_addr: '" + _spoofed_mac_addr + "'");
 
   int addr = 0;
   // Write header magic number
@@ -121,6 +131,9 @@ bool BoardPreference::write_preferences() {
   EEPROM.writeString(addr, _board_location);
   addr += _board_location.length() + 1;
   EEPROM.writeString(addr, _board_room);
+  addr += _board_room.length() + 1;
+  EEPROM.writeString(addr, _spoofed_mac_addr);
+  addr += _spoofed_mac_addr.length() + 1;
 
   if (!EEPROM.commit()) {
     Log.errorln("BoardPreference::write_preferences: error writing preferences to EEPROM");

--- a/src/board_preference.h
+++ b/src/board_preference.h
@@ -125,6 +125,41 @@ public:
     return write_preferences();
   }
 
+  /*
+   * Returns true if the board has enabled
+   * MAC address spoofing, false otherwise.
+   */
+  bool has_spoofed_mac() const {
+    return !_spoofed_mac_addr.isEmpty();
+  }
+
+  /*
+   * Returns the MAC address used for spoofing as
+   * a String of six hexidecimal values separated
+   * by column.
+   *
+   * In case MAC address spoofing is not enabled
+   * this function returns an empry String.
+   */
+  String get_spoofed_mac() const {
+    return _spoofed_mac_addr;
+  }
+
+  /*
+   * Set the MAC address used for spoofing.
+   *
+   * The address is passed as a String of six
+   * hexidecimal values separated by column.
+   *
+   * If the given address is empty the MAC address
+   * spoofing will be disabled and the connection
+   * will use the default one.
+   */
+  bool set_spoofed_mac(String mac) {
+    _spoofed_mac_addr = mac;
+    return write_preferences();
+  }
+
 private:
   /*
    * Available sensors are represented by 2 bytes (uint16_t)
@@ -137,6 +172,7 @@ private:
   String _board_host_name;
   String _board_location;
   String _board_room;
+  String _spoofed_mac_addr;
 
   bool read_preferences();
   bool write_preferences();

--- a/src/network/telnet.cpp
+++ b/src/network/telnet.cpp
@@ -1,10 +1,11 @@
 #include "telnet.h"
+#include "wifi.h"
 #include "../sensor/DHT11_sensor.h"
 #include "../sensor/SGP30_sensor.h"
 #include "../sensor/SPS30_sensor.h"
 #include "../sensor/MHZ19_sensor.h"
 
-#include "ESPTelnet.h"
+#include <ESPTelnet.h>
 
 static String string_divide_by(String *s, char delim) {
   size_t i = 0;
@@ -32,6 +33,7 @@ static void cmd_sensors_rm(String);
 static void cmd_board_host(String);
 static void cmd_board_location(String);
 static void cmd_board_room(String);
+static void cmd_mac_address(String);
 static void cmd_ping(String);
 static void cmd_reboot(String);
 static void cmd_version(String);
@@ -46,6 +48,7 @@ static const Cmd commands[] = {
   { "board-host", cmd_board_host, "get or set board's host name" },
   { "board-location", cmd_board_location, "get or set board's location" },
   { "board-room", cmd_board_room, "get or set board's room" },
+  { "mac", cmd_mac_address, "get or set MAC address (off to use default)" },
   { "ping", cmd_ping, "ping the board" },
   { "reboot", cmd_reboot, "reboot the board" },
   { "version", cmd_version, "show current firmware version" },
@@ -160,6 +163,30 @@ static void cmd_board_room(String new_room) {
   } else {
     Log.traceln("cmd_board_room: wanto to set the board room to '" + new_room + "'");
     Preference.set_board_room(new_room);
+  }
+}
+
+static void cmd_mac_address(String mac_addr) {
+  mac_addr.trim();
+  if (mac_addr.isEmpty()) {
+    Log.traceln("cmd_mac_address: wanto to get current MAC address");
+    telnet.println(wifi_get_mac_address());
+  } else if (mac_addr == "off") {
+    Log.traceln("cmd_mac_address: wants to disable MAC address spoofing");
+    if (!Preference.set_spoofed_mac("")) {
+      Log.errorln("cmd_mac_address: error disabling MAC address spoofing");
+      telnet.println("cannot disable MAC spoofing");
+    }
+  } else {
+    Log.traceln("cmd_mac_address: want to set MAC address to: '"
+                + mac_addr + "'");
+
+    if (!Preference.set_spoofed_mac(mac_addr)) {
+      telnet.println("cannot set MAC address");
+    }
+    telnet.println("rebooting board to apply the changes... you will be disconnected");
+    telnet.disconnectClient();
+    reboot_board(BOARD_REBOOT_DELAY_NOW);
   }
 }
 

--- a/src/network/telnet.cpp
+++ b/src/network/telnet.cpp
@@ -171,11 +171,15 @@ static void cmd_mac_address(String mac_addr) {
   if (mac_addr.isEmpty()) {
     Log.traceln("cmd_mac_address: wanto to get current MAC address");
     telnet.println(wifi_get_mac_address());
-  } else if (mac_addr == "off") {
+    return;
+  }
+
+  if (mac_addr == "off") {
     Log.traceln("cmd_mac_address: wants to disable MAC address spoofing");
     if (!Preference.set_spoofed_mac("")) {
       Log.errorln("cmd_mac_address: error disabling MAC address spoofing");
       telnet.println("cannot disable MAC spoofing");
+      return;
     }
   } else {
     Log.traceln("cmd_mac_address: want to set MAC address to: '"
@@ -183,11 +187,12 @@ static void cmd_mac_address(String mac_addr) {
 
     if (!Preference.set_spoofed_mac(mac_addr)) {
       telnet.println("cannot set MAC address");
+      return;
     }
-    telnet.println("rebooting board to apply the changes... you will be disconnected");
-    telnet.disconnectClient();
-    reboot_board(BOARD_REBOOT_DELAY_NOW);
   }
+  telnet.println("rebooting board to apply the changes... you will be disconnected");
+  telnet.disconnectClient();
+  reboot_board(BOARD_REBOOT_DELAY_NOW);
 }
 
 static void cmd_ping(String _) {

--- a/src/network/wifi.cpp
+++ b/src/network/wifi.cpp
@@ -56,6 +56,12 @@ bool wifi_connect(const char *ssid, const char *pwd,
 
   // Enable WiFi
   WiFi.mode(WIFI_STA);
+
+  // If board has MAC address spoofing set it
+  if (Preference.has_spoofed_mac()) {
+    set_mac_address(Preference.get_spoofed_mac());
+  }
+
   WiFi.begin(ssid, pwd);
   Log.debug("wifi_connect: connecing to WiFi");
 

--- a/src/network/wifi.cpp
+++ b/src/network/wifi.cpp
@@ -8,6 +8,40 @@
 static int old_backup_state = HIGH;
 #endif  // HAS_BACKUP_WIFI
 
+// TODO: Make function set_mac_address publicly available.
+//  Currently we call WiFi.mode(WIFI_STA) inside wifi_connect, so the WiFi
+//  interface is not initialized until we try to connect to a network.
+//  Using a public method to set the MAC address before connecting will always
+//  result in errors since the WiFi interface is never initialize.
+//  At the moment it's good setting the MAC privately only when connecting to a
+//  network, but, in case we implement the access piont we can let the user
+//  change the MAC.
+static void set_mac_address(String mac) {
+  int mac_val[6];
+  uint8_t mac_bytes[6];
+
+  // Parse MAC address string to bytes
+  int sz = sscanf(mac.c_str(), "%x:%x:%x:%x:%x:%x%*c",
+                  &mac_val[0], &mac_val[1], &mac_val[2],
+                  &mac_val[3], &mac_val[4], &mac_val[5]);
+  if (sz != 6) {
+    Log.errorln("set_mac_address: invalid MAC address: '" + mac + "'");
+    return;
+  }
+
+  for (int i = 0; i < 6; ++i) {
+    mac_bytes[i] = (uint8_t)mac_val[i];
+  }
+  esp_err_t err = esp_wifi_set_mac(WIFI_IF_STA, mac_bytes);
+  if (err == ESP_OK) {
+    Log.debugln("set_mac_address: new MAC address: "
+                + wifi_get_mac_address());
+  } else {
+    Log.traceln("set_mac_address: error setting MAC: "
+                + String(esp_err_to_name(err)));
+  }
+}
+
 bool wifi_connect(const char *ssid, const char *pwd,
                   int max_retry, int pause) {
   Log.traceln("wifi_connect: connecting to SSID: '" + String(ssid)
@@ -58,11 +92,6 @@ String wifi_get_ip() {
 
 String wifi_get_mac_address() {
   return WiFi.macAddress();
-}
-
-bool wifi_set_mac_address(uint8_t *mac) {
-  esp_err_t err = esp_wifi_set_mac(WIFI_IF_STA, mac);
-  return err == ESP_OK;
 }
 
 #ifdef HAS_BACKUP_WIFI

--- a/src/network/wifi.cpp
+++ b/src/network/wifi.cpp
@@ -1,5 +1,6 @@
 #include "wifi.h"
 
+#include <esp_wifi.h>
 #include <WiFi.h>
 #include "IPAddress.h"
 
@@ -57,6 +58,11 @@ String wifi_get_ip() {
 
 String wifi_get_mac_address() {
   return WiFi.macAddress();
+}
+
+bool wifi_set_mac_address(uint8_t *mac) {
+  esp_err_t err = esp_wifi_set_mac(WIFI_IF_STA, mac);
+  return err == ESP_OK;
 }
 
 #ifdef HAS_BACKUP_WIFI

--- a/src/network/wifi.h
+++ b/src/network/wifi.h
@@ -44,6 +44,14 @@ String wifi_get_ip();
 String wifi_get_mac_address();
 
 /*
+ * Set the board's MAC address to the given one.
+ *
+ * Returns true if the address is set succesfully,
+ * false otherwise.
+ */
+bool wifi_set_mac_address(uint8_t *mac);
+
+/*
  * Function representing a task running on the board
  * with the purpose of siwtching the WiFi connection
  * from the default one to the backup.

--- a/src/network/wifi.h
+++ b/src/network/wifi.h
@@ -44,14 +44,6 @@ String wifi_get_ip();
 String wifi_get_mac_address();
 
 /*
- * Set the board's MAC address to the given one.
- *
- * Returns true if the address is set succesfully,
- * false otherwise.
- */
-bool wifi_set_mac_address(uint8_t *mac);
-
-/*
  * Function representing a task running on the board
  * with the purpose of siwtching the WiFi connection
  * from the default one to the backup.


### PR DESCRIPTION
This PR introduces the ability to configure MAC address spoofing to the board.

Although not completely legitimate, MAC spoofing can be useful in situations when the WiFi connection is blocked or permitted to only specific devices. With this trick, the board can connect as normal to the internet.