### PR TITLE
Preference: Implement checksum for memory corruption detection

### DIFF
--- a/src/board_preference.cpp
+++ b/src/board_preference.cpp
@@ -26,7 +26,7 @@ bool BoardPreference::init() {
 }
 
 bool BoardPreference::clear() {
-  Log.traceln("BoardPreference::clear: restoring preferences to default state");
+  Log.debugln("BoardPreference::clear: restoring preferences to default state");
   _available_sensors_bytes = 0x0;
   _board_host_name         = "";
   _board_location          = "";
@@ -37,14 +37,13 @@ bool BoardPreference::clear() {
 }
 
 bool BoardPreference::read_preferences() {
-  Log.traceln("BoardPreference::read_preferences: reading board preferences "
-              "form EEPROM");
+  Log.debugln("BoardPreference::read_preferences: reading board preferences form EEPROM");
 
   int addr = 0;
   // Read header magic number and perform sanity check
   uint32_t magic = EEPROM.readUInt(addr);
   addr += sizeof(uint32_t);
-  Log.debugln("BoardPreference::read_preferences: header magic number: 0x" + String(magic, HEX));
+  Log.traceln("BoardPreference::read_preferences: header magic number: 0x" + String(magic, HEX));
   if (magic != PREFERENCES_HEADER_MAGIC) {
     Log.errorln("BoardPreference::read_preferences: error reading preferences; "
                 "expecting header magic number: 0x"
@@ -59,23 +58,23 @@ bool BoardPreference::read_preferences() {
   // Read other preferences
   _available_sensors_bytes = EEPROM.readUShort(addr);
   addr += sizeof(uint16_t);
-  Log.traceln("BoardPreference::read_preferences: _available_sensors_bytes: 0x"
+  Log.debugln("BoardPreference::read_preferences: _available_sensors_bytes: 0x"
               + String(_available_sensors_bytes, HEX));
   _board_host_name = EEPROM.readString(addr);
   addr += _board_host_name.length() + 1;
-  Log.traceln("BoardPreference::read_preferences: _board_host_name: '" + _board_host_name + "'");
+  Log.debugln("BoardPreference::read_preferences: _board_host_name: '" + _board_host_name + "'");
   _board_location = EEPROM.readString(addr);
   addr += _board_location.length() + 1;
-  Log.traceln("BoardPreference::read_preferences: _board_location: '" + _board_location + "'");
+  Log.debugln("BoardPreference::read_preferences: _board_location: '" + _board_location + "'");
   _board_room = EEPROM.readString(addr);
   addr += _board_room.length() + 1;
-  Log.traceln("BoardPreference::read_preferences: _board_room: '" + _board_room + "'");
+  Log.debugln("BoardPreference::read_preferences: _board_room: '" + _board_room + "'");
   _spoofed_mac_addr = EEPROM.readString(addr);
   addr += _spoofed_mac_addr.length() + 1;
-  Log.traceln("BoardPreference::read_preferences: _spoofed_mac_addr: '" + _spoofed_mac_addr + "'");
+  Log.debugln("BoardPreference::read_preferences: _spoofed_mac_addr: '" + _spoofed_mac_addr + "'");
   _temperature_offset = EEPROM.readByte(addr);
   addr += sizeof(uint8_t);
-  Log.traceln("BoardPreference::read_preferences: _temperature_offset: "
+  Log.debugln("BoardPreference::read_preferences: _temperature_offset: "
               + String(_temperature_offset));
 
   // Compute checksum of the parameter just read and check
@@ -83,21 +82,21 @@ bool BoardPreference::read_preferences() {
   uint16_t new_checksum = checksum();
   if (old_checksum != new_checksum) {
     Log.errorln("BoardPreference::read_preferences: checksum is not equal to the one stored ("
-                + String(old_checksum) + "!="
-                + String(new_checksum) + ")");
+                + String(old_checksum) + "!=" + String(new_checksum) + ")");
     return false;
   }
   return true;
 }
 
 bool BoardPreference::write_preferences() {
-  Log.traceln("BoardPreference::write_preferences: writing board preferences "
-              "to EEPROM");
-  Log.traceln("BoardPreference::write_preferences: _available_sensors_bytes: '0x"
-              + String(_available_sensors_bytes, HEX) + "', " + "_board_host_name: '"
-              + _board_host_name + "', " + "_board_location: '" + _board_location + "', "
-              + "_board_room: '" + _board_room + "'" + "_spoofed_mac_addr: '" + _spoofed_mac_addr
-              + "'");
+  Log.debugln("BoardPreference::write_preferences: writing board preferences to EEPROM");
+  Log.trace("BoardPreference::write_preferences: ");
+  Log.trace("_available_sensors_bytes: '0x" + String(_available_sensors_bytes, HEX) + "', ");
+  Log.trace("_board_host_name: '" + _board_host_name + "', ");
+  Log.trace("_board_location: '" + _board_location + "', ");
+  Log.trace("_board_room: '" + _board_room + "', ");
+  Log.trace("_spoofed_mac_addr: '" + _spoofed_mac_addr + "', ");
+  Log.traceln("_temperature_offset: '" + String(_temperature_offset) + "'");
 
   int addr = 0;
   // Write header magic number
@@ -141,38 +140,26 @@ void BoardPreference::create_checksum_prefs_buffer() {
     free(_checksum_buffer);
   }
   _checksum_buffer = (uint8_t *)malloc(_checksum_buffer_sz);
-  Log.traceln("BoardPreference::create_checksum_prefs_buffer: create checksum buffer with size " + String(_checksum_buffer_sz));
+  Log.traceln("BoardPreference::create_checksum_prefs_buffer: create checksum buffer with size "
+              + String(_checksum_buffer_sz));
 
   size_t address = 0;
-  memcpy((_checksum_buffer + address),
-         &_available_sensors_bytes,
-         sizeof(_available_sensors_bytes));
+  memcpy((_checksum_buffer + address), &_available_sensors_bytes, sizeof(_available_sensors_bytes));
   address += sizeof(_available_sensors_bytes);
-  memcpy((_checksum_buffer + address),
-         _board_host_name.c_str(),
-         _board_host_name.length());
+  memcpy((_checksum_buffer + address), _board_host_name.c_str(), _board_host_name.length());
   address += _board_host_name.length();
-  memcpy((_checksum_buffer + address),
-         _board_location.c_str(),
-         _board_location.length());
+  memcpy((_checksum_buffer + address), _board_location.c_str(), _board_location.length());
   address += _board_location.length();
-  memcpy((_checksum_buffer + address),
-         _board_room.c_str(),
-         _board_room.length());
+  memcpy((_checksum_buffer + address), _board_room.c_str(), _board_room.length());
   address += _board_room.length();
-  memcpy((_checksum_buffer + address),
-         _spoofed_mac_addr.c_str(),
-         _spoofed_mac_addr.length());
+  memcpy((_checksum_buffer + address), _spoofed_mac_addr.c_str(), _spoofed_mac_addr.length());
   address += _spoofed_mac_addr.length();
-  memcpy((_checksum_buffer + address),
-         &_temperature_offset,
-         sizeof(_temperature_offset));
+  memcpy((_checksum_buffer + address), &_temperature_offset, sizeof(_temperature_offset));
   address += sizeof(_temperature_offset);
 }
 
 uint16_t BoardPreference::checksum() {
-  uint8_t a = 1,
-          b = 0;
+  uint8_t a = 1, b = 0;
 
   // Compute the checksum from the preferences as buffer
   create_checksum_prefs_buffer();
@@ -182,7 +169,6 @@ uint16_t BoardPreference::checksum() {
   }
 
   uint16_t cs = ((b << 8) | a);
-  Log.traceln("BoardPreference::checksum: computed checksum '"
-              + String(cs) + "'");
+  Log.traceln("BoardPreference::checksum: computed checksum '" + String(cs) + "'");
   return cs;
 }

--- a/src/board_preference.cpp
+++ b/src/board_preference.cpp
@@ -36,42 +36,6 @@ bool BoardPreference::clear() {
   return write_preferences();
 }
 
-bool BoardPreference::has_sensor(SensorType s) {
-  assert(s < SensorType::COUNT_SENSORS);
-  return (bool)_PREF_HAS_SENSOR_BIT(_available_sensors_bytes, s);
-}
-
-bool BoardPreference::add_sensor(SensorType s) {
-  assert(s < SensorType::COUNT_SENSORS);
-  Log.traceln("BoardPreference::add_sensor: " + SensorType_to_String(s));
-  _PREF_SET_SENSOR_BIT(_available_sensors_bytes, s);
-  return write_preferences();
-}
-
-bool BoardPreference::remove_sensor(SensorType s) {
-  assert(s < SensorType::COUNT_SENSORS);
-  Log.traceln("BoardPreference::remove_sensor: " + SensorType_to_String(s));
-  _PREF_UNSET_SENSOR_BIT(_available_sensors_bytes, s);
-  return write_preferences();
-}
-
-String BoardPreference::available_sensors_to_String() {
-  String ret = "[";
-
-  bool is_first = true;
-  for (int i = 0; i < SensorType::COUNT_SENSORS; ++i) {
-    if (has_sensor((SensorType)i)) {
-      if (!is_first) {
-        ret += ", ";
-      }
-      ret += SensorType_to_String((SensorType)i);
-      is_first = false;
-    }
-  }
-  ret += "]";
-  return ret;
-}
-
 bool BoardPreference::read_preferences() {
   Log.traceln("BoardPreference::read_preferences: reading board preferences "
               "form EEPROM");

--- a/src/board_preference.h
+++ b/src/board_preference.h
@@ -13,12 +13,9 @@
 #define DEFAULT_BOARD_LOCATION  "default_location"
 #define DEFAULT_BOARD_ROOM      "default_room"
 
-#define _PREF_HAS_SENSOR_BIT(bytes, idx) \
-  (((bytes >> (uint16_t)idx)) & (uint16_t)0x01)
-#define _PREF_SET_SENSOR_BIT(bytes, idx) \
-  bytes |= ((uint16_t)0x01 << (uint16_t)idx)
-#define _PREF_UNSET_SENSOR_BIT(bytes, idx) \
-  bytes &= ~((uint16_t)0x01 << (uint16_t)idx)
+#define _PREF_HAS_SENSOR_BIT(bytes, idx)   (((bytes >> (uint16_t)idx)) & (uint16_t)0x01)
+#define _PREF_SET_SENSOR_BIT(bytes, idx)   bytes |= ((uint16_t)0x01 << (uint16_t)idx)
+#define _PREF_UNSET_SENSOR_BIT(bytes, idx) bytes &= ~((uint16_t)0x01 << (uint16_t)idx)
 
 /*
  * Class representing board's global preferences.
@@ -192,9 +189,7 @@ class BoardPreference {
   /*
    * Returns the offset used for temperature calibration.
    */
-  int8_t get_temperature_offset() const {
-    return _temperature_offset;
-  }
+  int8_t get_temperature_offset() const { return _temperature_offset; }
 
   /*
    * Set the offset used for temperature calibration.
@@ -220,8 +215,8 @@ class BoardPreference {
   uint8_t  _temperature_offset = 0;
 
   // Checksum internal buffer.
-  uint8_t *_checksum_buffer = nullptr;
-  size_t _checksum_buffer_sz = 0;
+  uint8_t *_checksum_buffer    = nullptr;
+  size_t   _checksum_buffer_sz = 0;
 
   bool read_preferences();
   bool write_preferences();
@@ -235,7 +230,7 @@ class BoardPreference {
    * Returns the computed checksum as a 16bit unsigned int.
    */
   uint16_t checksum();
-  void create_checksum_prefs_buffer();
+  void     create_checksum_prefs_buffer();
 };
 
 /*

--- a/src/board_preference.h
+++ b/src/board_preference.h
@@ -219,8 +219,23 @@ class BoardPreference {
   String   _spoofed_mac_addr;
   uint8_t  _temperature_offset = 0;
 
+  // Checksum internal buffer.
+  uint8_t *_checksum_buffer = nullptr;
+  size_t _checksum_buffer_sz = 0;
+
   bool read_preferences();
   bool write_preferences();
+  /*
+   * Compute the checksum from all the preferences
+   * stored inside the board's EEPROM.
+   *
+   * This checksum function implements a 16bit version
+   * of the Adler-32 algorithm.
+   *
+   * Returns the computed checksum as a 16bit unsigned int.
+   */
+  uint16_t checksum();
+  void create_checksum_prefs_buffer();
 };
 
 /*


### PR DESCRIPTION
In this PR we implement the ability to check for memory corruption of the preferences stored inside the board's EEPROM.

To do so we use a checksum function that is a variation of the Adler32 algorithm, but using only 16bits. This algorithm is easy to perform and takes less memory, so it's suited for ESP devices.

When merged this PR will close #20 