### PR TITLE
Sensor: Add new interfaces

### DIFF
--- a/src/sensor/DHT11_sensor.cpp
+++ b/src/sensor/DHT11_sensor.cpp
@@ -8,32 +8,20 @@ DHT11_Sensor::DHT11_Sensor()
     _temperature(0.0),
     _humidity(0.0) {}
 
-bool DHT11_Sensor::init() {
-  if (p_is_init) {
-    Log.traceln("DHT11_Sensor::init: sensor already initialized");
-    return true;
-  }
-
+bool DHT11_Sensor::on_init() {
   _dht.begin();
   delay(DHT11_INIT_DELAY_MS);
   Log.traceln("DHT11_Sensor::init: sensor initialized");
-
-  p_is_init = true;
   return true;
 }
 
-bool DHT11_Sensor::measure() {
+bool DHT11_Sensor::on_measure() {
   float currentT = 0.0,
         currentH = 0.0,
         maxT = 0.0,
         minT = 0.0,
         maxH = 0.0,
         minH = 0.0;
-
-  if (!p_is_init) {
-    Log.errorln("DHT11_Sensor::measure: sensor not initialized");
-    return false;
-  }
 
   Log.traceln("DHT11_Sensor::measure: reading sensor values");
   _temperature = 0.0;

--- a/src/sensor/DHT11_sensor.h
+++ b/src/sensor/DHT11_sensor.h
@@ -12,8 +12,8 @@ class DHT11_Sensor : public AbstractSensor {
 public:
   DHT11_Sensor();
 
-  bool init() override;
-  bool measure() override;
+  bool on_init() override;
+  bool on_measure() override;
 
   /*
    * Return the last measured temperature.

--- a/src/sensor/MHZ19_sensor.cpp
+++ b/src/sensor/MHZ19_sensor.cpp
@@ -3,31 +3,19 @@
 
 MHZ19_Sensor MHZ19Sensor;
 
-bool MHZ19_Sensor::init() {
-  if (p_is_init) {
-    Log.traceln("MHZ19_Sensor::init: sensor already initialized");
-    return true;
-  }
-
+bool MHZ19_Sensor::on_init() {
   MHZ19_SERIAL.begin(MHZ19_BAUD_RATE, SERIAL_8N1, MHZ19_RX, MHZ19_TX);
   _mhz.begin(&MHZ19_SERIAL);
 
   delay(MHZ19_INIT_DELAY_MS);
   Log.traceln("MHZ19_Sensor::init: sensor initialized");
-
-  p_is_init = true;
   return true;
 }
 
-bool MHZ19_Sensor::measure() {
+bool MHZ19_Sensor::on_measure() {
   int currentCo2 = 0,
       minCo2 = 0,
       maxCo2 = 0;
-
-  if (!p_is_init) {
-    Log.errorln("MHZ19_Sensor::measure: sensor not initialized");
-    return false;
-  }
 
   Log.traceln("MHZ19_Sensor::measure: reading sensor values");
   for (int i = 0; i < SENSOR_AVG_WINDOW; ++i) {

--- a/src/sensor/MHZ19_sensor.h
+++ b/src/sensor/MHZ19_sensor.h
@@ -10,8 +10,8 @@
 
 class MHZ19_Sensor : public AbstractSensor {
 public:
-  bool init() override;
-  bool measure() override;
+  bool on_init() override;
+  bool on_measure() override;
 
   /*
    * Returns the last measured CO2.

--- a/src/sensor/SGP30_sensor.cpp
+++ b/src/sensor/SGP30_sensor.cpp
@@ -6,35 +6,23 @@
 
 SGP30_Sensor SGP30Sensor;
 
-bool SGP30_Sensor::init() {
-  if (p_is_init) {
-    Log.traceln("SGP30_Sensor::init: sensor already initialized");
-    return true;
-  }
-
+bool SGP30_Sensor::on_init() {
   if (!_sgp.begin()) {
     Log.errorln("SGP30_Sensor::init: sensor not found");
     return false;
   }
   delay(SGP30_INIT_DELAY_MS);
   Log.traceln("SGP30_Sensor::init: sensor initialized");
-
-  p_is_init = true;
   return true;
 }
 
-bool SGP30_Sensor::measure() {
+bool SGP30_Sensor::on_measure() {
   uint16_t currentTvoc = 0.0,
            currentEco2 = 0.0,
            minTvoc = 0.0,
            maxTvoc = 0.0,
            minEco2 = 0.0,
            maxEco2 = 0.0;
-
-  if (!p_is_init) {
-    Log.infoln("SGP30_Sensor::measure: sensor not initialized");
-    return false;
-  }
 
   Log.traceln("SGP30_Sensor::measure: reading sensor values");
   if (DHT11Sensor.get_temperature() > 0) {

--- a/src/sensor/SGP30_sensor.h
+++ b/src/sensor/SGP30_sensor.h
@@ -12,8 +12,8 @@
 
 class SGP30_Sensor : public AbstractSensor {
 public:
-  bool init() override;
-  bool measure() override;
+  bool on_init() override;
+  bool on_measure() override;
 
   /*
    * Return the last measured Total Volatile Organic

--- a/src/sensor/SPS30_sensor.cpp
+++ b/src/sensor/SPS30_sensor.cpp
@@ -5,13 +5,8 @@
 
 SPS30_Sensor SPS30Sensor;
 
-bool SPS30_Sensor::init() {
+bool SPS30_Sensor::on_init() {
   int16_t ret;
-
-  if (p_is_init) {
-    Log.traceln("SPS30_Sensor::init: sensor already initialized");
-    return true;
-  }
 
   sensirion_i2c_init();
 
@@ -44,19 +39,12 @@ bool SPS30_Sensor::init() {
 
   delay(SPS30_INIT_DELAY_MS);
   Log.traceln("SPS30_Sensor::init: sensor initialized");
-
-  p_is_init = true;
   return true;
 }
 
-bool SPS30_Sensor::measure() {
+bool SPS30_Sensor::on_measure() {
   int16_t ret;
   uint16_t data_ready;
-
-  if (!p_is_init) {
-    Log.infoln("SPS30_Sensor::init: sensor not initialized");
-    return false;
-  }
 
   Log.traceln("SPS30_Sensor::measure: reading sensor values");
   delay(1000);

--- a/src/sensor/SPS30_sensor.h
+++ b/src/sensor/SPS30_sensor.h
@@ -14,8 +14,8 @@
 
 class SPS30_Sensor : public AbstractSensor {
 public:
-  bool init() override;
-  bool measure() override;
+  bool on_init() override;
+  bool on_measure() override;
 
   /*
    * Returns the last measured MC 1.0

--- a/src/sensor/abstract_sensor.cpp
+++ b/src/sensor/abstract_sensor.cpp
@@ -1,0 +1,19 @@
+#include "abstract_sensor.h"
+
+bool AbstractSensor::init() {
+  if (p_is_init) {
+    return true;
+  }
+
+  bool init_res = on_init();
+  p_is_init = init_res;
+  return init_res;
+}
+
+bool AbstractSensor::measure() {
+  if (!p_is_init) {
+    return true;
+  }
+
+  return on_measure();
+}

--- a/src/sensor/abstract_sensor.h
+++ b/src/sensor/abstract_sensor.h
@@ -16,7 +16,7 @@ public:
    * Returns true if the initialization is
    * successful, false otherwise.
    */
-  virtual bool init() = 0;
+  bool init();
 
   /*
    * Measure the values from the sensor.
@@ -24,13 +24,25 @@ public:
    * Returns true if the measure is successful,
    * false otherwise.
    */
-  virtual bool measure() = 0;
+  bool measure();
 
 protected:
   /*
    * Variable stating if the sensor is already initialized.
    */
   bool p_is_init = false;
+
+  /*
+   * Interface method implemented by the child class
+   * to perform the init of his sensor.
+   */
+  virtual bool on_init() = 0;
+
+  /*
+   * Interface method implemented by the child class
+   * to perform a measure of his sensor.
+   */
+  virtual bool on_measure() = 0;
 };
 
 #endif  // ABSTRACT_SENSOR_H


### PR DESCRIPTION
This PR adds two new virtual methods to `AbstractSensor`: 

- `on_init` 
- `on_measure`
 
The old `init` and `measure` virtual methods now are implemented directly by the abstract class and act as a public API while the new protected methods act as the implementation. 

This is done to ensure that all the classes check and set the sensor init in a constant way. Now this check is done in the base class for everyone, and the children need only to specify their logic.

When merged this PR will close #35 