### PR TITLE
Format: Use `clang-format` to automatically format source code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,213 @@
+BasedOnStyle: LLVM
+TabWidth: 4
+IndentWidth: 4
+UseTab: Always
+ColumnLimit: 100
+
+---
+Language: Cpp
+
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Left
+
+AlignConsecutiveAssignments: Consecutive
+AlignConsecutiveBitFields: Consecutive
+AlignConsecutiveDeclarations: Consecutive
+AlignConsecutiveMacros: Consecutive
+
+AlignEscapedNewlines: Left
+AlignOperands: Align
+AlignTrailingComments:
+  Kind: Always
+  OverEmptyLines:  0
+
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+
+BinPackArguments: false
+BinPackParameters: false
+BitFieldColonSpacing: After
+
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: MultiLine
+  AfterEnum:       false
+  AfterExternBlock: false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAfterAttributes: Never
+BreakArrays: true
+BreakBeforeBinaryOperators: All
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: AfterComma
+BreakStringLiterals: true
+
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+FixNamespaceComments: true
+
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+
+IncludeBlocks:   Regroup
+IncludeCategories:
+  # Headers in <> without extension.
+  - Regex:           '<([A-Za-z0-9\Q/-_\E])+>'
+    Priority:        4
+  # Headers in <> from specific external libraries.
+  - Regex:           '<(catch2|boost)\/'
+    Priority:        3
+  # Headers in <> with extension.
+  - Regex:           '<([A-Za-z0-9.\Q/-_\E])+>'
+    Priority:        2
+  # Headers in "" with extension.
+  - Regex:           '"([A-Za-z0-9.\Q/-_\E])+"'
+    Priority:        1
+IncludeIsMainRegex: '(_test)?$'
+IncludeIsMainSourceRegex: ''
+
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: false
+IndentPPDirectives: AfterHash
+IndentRequiresClause: true
+IndentWrappedFunctionNames: true
+InsertBraces: true
+InsertNewlineAtEOF: true
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+LineEnding:      LF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
+
+PPIndentWidth:   -1
+
+PointerAlignment: Right
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+
+ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveSemicolon: false
+
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+
+SeparateDefinitionBlocks: Always
+ShortNamespaceLines: 1
+
+SortIncludes:    CaseSensitive
+SortUsingDeclarations: LexicographicNumeric
+
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+Standard:        Latest
+
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE

--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 BasedOnStyle: LLVM
 TabWidth: 4
-IndentWidth: 4
-UseTab: Always
+IndentWidth: 2
+UseTab: Never
 ColumnLimit: 100
 
 ---
@@ -92,16 +92,16 @@ IncludeBlocks:   Regroup
 IncludeCategories:
   # Headers in <> without extension.
   - Regex:           '<([A-Za-z0-9\Q/-_\E])+>'
-    Priority:        4
+    Priority:        1
   # Headers in <> from specific external libraries.
   - Regex:           '<(catch2|boost)\/'
-    Priority:        3
+    Priority:        2
   # Headers in <> with extension.
   - Regex:           '<([A-Za-z0-9.\Q/-_\E])+>'
-    Priority:        2
+    Priority:        3
   # Headers in "" with extension.
   - Regex:           '"([A-Za-z0-9.\Q/-_\E])+"'
-    Priority:        1
+    Priority:        4
 IncludeIsMainRegex: '(_test)?$'
 IncludeIsMainSourceRegex: ''
 

--- a/.clang-format
+++ b/.clang-format
@@ -161,7 +161,6 @@ SeparateDefinitionBlocks: Always
 ShortNamespaceLines: 1
 
 SortIncludes:    CaseSensitive
-SortUsingDeclarations: LexicographicNumeric
 
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false

--- a/.clang-format
+++ b/.clang-format
@@ -18,9 +18,9 @@ AlignConsecutiveMacros: Consecutive
 
 AlignEscapedNewlines: Left
 AlignOperands: Align
-AlignTrailingComments:
-  Kind: Always
-  OverEmptyLines:  0
+AlignTrailingComments: true
+#  Kind: Always
+#  OverEmptyLines:  0
 
 AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: false
@@ -58,12 +58,12 @@ BraceWrapping:
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
-BreakAfterAttributes: Never
-BreakArrays: true
+#BreakAfterAttributes: Never
+#BreakArrays: true
 BreakBeforeBinaryOperators: All
 BreakBeforeConceptDeclarations: Always
 BreakBeforeBraces: Custom
-BreakBeforeInlineASMColon: OnlyMultiline
+#BreakBeforeInlineASMColon: OnlyMultiline
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
 BreakInheritanceList: AfterComma
@@ -114,19 +114,19 @@ IndentPPDirectives: AfterHash
 IndentRequiresClause: true
 IndentWrappedFunctionNames: true
 InsertBraces: true
-InsertNewlineAtEOF: true
+#InsertNewlineAtEOF: true
 InsertTrailingCommas: None
-IntegerLiteralSeparator:
-  Binary:          0
-  BinaryMinDigits: 0
-  Decimal:         0
-  DecimalMinDigits: 0
-  Hex:             0
-  HexMinDigits:    0
+#IntegerLiteralSeparator:
+#  Binary:          0
+#  BinaryMinDigits: 0
+#  Decimal:         0
+#  DecimalMinDigits: 0
+#  Hex:             0
+#  HexMinDigits:    0
 
 KeepEmptyLinesAtTheStartOfBlocks: false
 LambdaBodyIndentation: Signature
-LineEnding:      LF
+#LineEnding:      LF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
@@ -152,10 +152,10 @@ ReferenceAlignment: Pointer
 
 ReflowComments:  true
 RemoveBracesLLVM: false
-RemoveSemicolon: false
+#RemoveSemicolon: false
 
 RequiresClausePosition: OwnLine
-RequiresExpressionIndentation: OuterScope
+#RequiresExpressionIndentation: OuterScope
 
 SeparateDefinitionBlocks: Always
 ShortNamespaceLines: 1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Check Format
+name: Lint
 on:
   push:
     branches:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lint:
-    name: Check code base format
+    name: Check code base Format
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -20,4 +20,4 @@ jobs:
         with:
           source: '. src'
           extensions: 'h,cpp,ino'
-          clangFormatVersion: 16
+          clangFormatVersion: 15

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,16 +13,13 @@ jobs:
     name: Check code base Format
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    strategy:
-      matrix:
-        path:
-          - check: '.'
-          - check: 'src'
     steps:
-    - uses: actions/checkout@v3
-    - name: Run clang-format style check for all codebase
-      uses: jidicula/clang-format-action@v4.11.0
-      with:
-        clang-format-version: '16'
-        check-path: ${{ matrix.path['check'] }}
-        exclude-regex: ${{ matrix.path['exclude'] }}
+      - name: Install clang-format
+        run: >-
+          apt-get update &&
+          apt-get install --no-install-recommends -y clang-format-16 &&
+          mv /usr/bin/clang-format-16 /usr/bin/clang-format
+      - uses: actions/checkout@v3
+      - name: Run clang-format style check for all codebase
+        run: >-
+          clang-format --dry-run --Werror **/*.h **/*.cpp **/*.ino

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,12 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Install clang-format
-        run: >-
-          sudo apt-get update &&
-          sudo apt-get install --no-install-recommends -y clang-format-16 &&
-          sudo mv /usr/bin/clang-format-16 /usr/bin/clang-format
       - uses: actions/checkout@v3
-      - name: Run clang-format style check for all codebase
-        run: >-
-          clang-format --dry-run --Werror **/*.h **/*.cpp **/*.ino
+      - uses: Ballen7/clang-format-lint-action@clang-format-16
+        with:
+          source: '. src'
+          extensions: 'h,cpp,ino'
+          clangFormatVersion: 16

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,4 +20,4 @@ jobs:
         with:
           source: '. src'
           extensions: 'h,cpp,ino'
-          clangFormatVersion: 15
+          clangFormatVersion: 15.0.2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,11 +13,16 @@ jobs:
     name: Check code base Format
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      matrix:
+        path:
+          - check: '.'
+          - check: 'src'
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: DoozyX/clang-format-lint-action@v0.14
-        with:
-          source: '. src'
-          extensions: 'h,cpp,ino'
-          clangFormatVersion: 14
+    - uses: actions/checkout@v3
+    - name: Run clang-format style check for all codebase
+      uses: jidicula/clang-format-action@v4.11.0
+      with:
+        clang-format-version: '16'
+        check-path: ${{ matrix.path['check'] }}
+        exclude-regex: ${{ matrix.path['exclude'] }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,9 +16,9 @@ jobs:
     steps:
       - name: Install clang-format
         run: >-
-          apt-get update &&
-          apt-get install --no-install-recommends -y clang-format-16 &&
-          mv /usr/bin/clang-format-16 /usr/bin/clang-format
+          sudo apt-get update &&
+          sudo apt-get install --no-install-recommends -y clang-format-16 &&
+          sudo mv /usr/bin/clang-format-16 /usr/bin/clang-format
       - uses: actions/checkout@v3
       - name: Run clang-format style check for all codebase
         run: >-

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,8 +15,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
-      - uses: Ballen7/clang-format-lint-action@clang-format-16
+      - uses: DoozyX/clang-format-lint-action@v0.15
         with:
           source: '. src'
           extensions: 'h,cpp,ino'
-          clangFormatVersion: 16
+          clangFormatVersion: 15.0.2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,4 +20,4 @@ jobs:
         with:
           source: '. src'
           extensions: 'h,cpp,ino'
-          clangFormatVersion: 15.0.2
+          clangFormatVersion: 14

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,23 @@
+name: Check Format
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  lint:
+    name: Check code base format
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: DoozyX/clang-format-lint-action@v0.14
+        with:
+          source: '. src'
+          extensions: 'h,cpp,ino'
+          clangFormatVersion: 16

--- a/iot_uniurb.ino
+++ b/iot_uniurb.ino
@@ -1,10 +1,10 @@
 #include "src/common.h"
 #include "src/network/wifi.h"
 #ifdef HAS_INFLUXDB
-#	include "src/network/influxdb.h"
+#  include "src/network/influxdb.h"
 #endif // HAS_INFLUXDB
 #ifdef HAS_TELNET
-#	include "src/network/telnet.h"
+#  include "src/network/telnet.h"
 #endif // HAS_TELNET
 #include "src/sensor_helper.h"
 
@@ -17,74 +17,74 @@ TaskHandle_t telnet_task_handler;
 #endif // HAS_TELNET
 
 void setup() {
-	// Init logger
-	Log.init(BAUD_RATE);
+  // Init logger
+  Log.init(BAUD_RATE);
 
-	// Init preferences
-	if (!Preference.init()) {
-		Log.errorln("something went wrong initializing board preferences");
-	}
+  // Init preferences
+  if (!Preference.init()) {
+    Log.errorln("something went wrong initializing board preferences");
+  }
 
-	Log.infoln("Available Sensors:   " + Preference.available_sensors_to_String());
-	Log.infoln("Device Host Name:   '" + Preference.get_board_host_name() + "'");
-	Log.infoln("Device Location:    '" + Preference.get_board_location() + "'");
-	Log.infoln("Device Room:        '" + Preference.get_board_room() + "'");
+  Log.infoln("Available Sensors:   " + Preference.available_sensors_to_String());
+  Log.infoln("Device Host Name:   '" + Preference.get_board_host_name() + "'");
+  Log.infoln("Device Location:    '" + Preference.get_board_location() + "'");
+  Log.infoln("Device Room:        '" + Preference.get_board_room() + "'");
 
 #ifdef HAS_BACKUP_WIFI
-	xTaskCreatePinnedToCore(wifi_backup_task_code,
-							"wifi_backup_task",
-							WIFI_BACKUP_TASK_STACK_SIZE,
-							nullptr,
-							WIFI_BACKUP_TASK_PRIORITY,
-							&wifi_backup_task_handler,
-							WIFI_BACKUP_TASK_CORE);
+  xTaskCreatePinnedToCore(wifi_backup_task_code,
+                          "wifi_backup_task",
+                          WIFI_BACKUP_TASK_STACK_SIZE,
+                          nullptr,
+                          WIFI_BACKUP_TASK_PRIORITY,
+                          &wifi_backup_task_handler,
+                          WIFI_BACKUP_TASK_CORE);
 #endif // HAS_BACKUP_WIFI
 
-	Log.infoln("MAC Address:        '" + wifi_get_mac_address() + "'");
-	Log.infoln("SSID:               '" + String(WIFI_SSID) + "'");
-	// Connecto to WiFi network
-	if (!wifi_connect(WIFI_SSID, WIFI_PWD)) {
-		Log.fatalln("something went wrong connecting to WiFi");
-		reboot_board();
-	}
-	Log.infoln("Device IP:          '" + wifi_get_ip() + "'");
+  Log.infoln("MAC Address:        '" + wifi_get_mac_address() + "'");
+  Log.infoln("SSID:               '" + String(WIFI_SSID) + "'");
+  // Connecto to WiFi network
+  if (!wifi_connect(WIFI_SSID, WIFI_PWD)) {
+    Log.fatalln("something went wrong connecting to WiFi");
+    reboot_board();
+  }
+  Log.infoln("Device IP:          '" + wifi_get_ip() + "'");
 
 #ifdef HAS_TELNET
-	// Init telnet
-	if (telnet_init()) {
-		xTaskCreatePinnedToCore(telnet_task_code,
-								"telnet_task",
-								TELNET_TASK_STACK_SIZE,
-								nullptr,
-								TELNET_TASK_PRIORITY,
-								&telnet_task_handler,
-								TELNET_TASK_CORE);
-	} else {
-		Log.errorln("something went wrong initializing Telnet");
-	}
+  // Init telnet
+  if (telnet_init()) {
+    xTaskCreatePinnedToCore(telnet_task_code,
+                            "telnet_task",
+                            TELNET_TASK_STACK_SIZE,
+                            nullptr,
+                            TELNET_TASK_PRIORITY,
+                            &telnet_task_handler,
+                            TELNET_TASK_CORE);
+  } else {
+    Log.errorln("something went wrong initializing Telnet");
+  }
 #endif // HAS_TELNET
 
 #ifdef HAS_INFLUXDB
-	// Init InfluxDB
-	Log.infoln("InfluxDB url:       '" INFLUXDB_URL "'");
-	Log.infoln("InfluxDB org:       '" INFLUXDB_ORG "'");
-	Log.infoln("InfluxDB bucket:    '" INFLUXDB_BUCKET "'");
+  // Init InfluxDB
+  Log.infoln("InfluxDB url:       '" INFLUXDB_URL "'");
+  Log.infoln("InfluxDB org:       '" INFLUXDB_ORG "'");
+  Log.infoln("InfluxDB bucket:    '" INFLUXDB_BUCKET "'");
 
-	if (!influxdb_init()) {
-		Log.fatalln("something went wrong initializing InfluxDB");
-	}
+  if (!influxdb_init()) {
+    Log.fatalln("something went wrong initializing InfluxDB");
+  }
 #endif // HAS_INFLUXDB
 
-	// Init available sensors
-	init_all_available_sensors();
+  // Init available sensors
+  init_all_available_sensors();
 
-	xTaskCreatePinnedToCore(measure_and_send_task_code,
-							"measure_task",
-							MEASURE_TASK_STACK_SIZE,
-							nullptr,
-							MEASURE_TASK_PRIORITY,
-							&measure_task_handler,
-							MEASURE_TASK_CORE);
+  xTaskCreatePinnedToCore(measure_and_send_task_code,
+                          "measure_task",
+                          MEASURE_TASK_STACK_SIZE,
+                          nullptr,
+                          MEASURE_TASK_PRIORITY,
+                          &measure_task_handler,
+                          MEASURE_TASK_CORE);
 }
 
 void loop() {}

--- a/iot_uniurb.ino
+++ b/iot_uniurb.ino
@@ -1,90 +1,90 @@
 #include "src/common.h"
 #include "src/network/wifi.h"
 #ifdef HAS_INFLUXDB
-#include "src/network/influxdb.h"
-#endif  // HAS_INFLUXDB
+#	include "src/network/influxdb.h"
+#endif // HAS_INFLUXDB
 #ifdef HAS_TELNET
-#include "src/network/telnet.h"
-#endif  // HAS_TELNET
+#	include "src/network/telnet.h"
+#endif // HAS_TELNET
 #include "src/sensor_helper.h"
 
 TaskHandle_t measure_task_handler;
 #ifdef HAS_BACKUP_WIFI
 TaskHandle_t wifi_backup_task_handler;
-#endif  // HAS_BACKUP_WIFI
+#endif // HAS_BACKUP_WIFI
 #ifdef HAS_TELNET
 TaskHandle_t telnet_task_handler;
-#endif  // HAS_TELNET
+#endif // HAS_TELNET
 
 void setup() {
-  // Init logger
-  Log.init(BAUD_RATE);
+	// Init logger
+	Log.init(BAUD_RATE);
 
-  // Init preferences
-  if (!Preference.init()) {
-    Log.errorln("something went wrong initializing board preferences");
-  }
+	// Init preferences
+	if (!Preference.init()) {
+		Log.errorln("something went wrong initializing board preferences");
+	}
 
-  Log.infoln("Available Sensors:   " + Preference.available_sensors_to_String());
-  Log.infoln("Device Host Name:   '" + Preference.get_board_host_name() + "'");
-  Log.infoln("Device Location:    '" + Preference.get_board_location() + "'");
-  Log.infoln("Device Room:        '" + Preference.get_board_room() + "'");
+	Log.infoln("Available Sensors:   " + Preference.available_sensors_to_String());
+	Log.infoln("Device Host Name:   '" + Preference.get_board_host_name() + "'");
+	Log.infoln("Device Location:    '" + Preference.get_board_location() + "'");
+	Log.infoln("Device Room:        '" + Preference.get_board_room() + "'");
 
 #ifdef HAS_BACKUP_WIFI
-  xTaskCreatePinnedToCore(wifi_backup_task_code,
-                          "wifi_backup_task",
-                          WIFI_BACKUP_TASK_STACK_SIZE,
-                          nullptr,
-                          WIFI_BACKUP_TASK_PRIORITY,
-                          &wifi_backup_task_handler,
-                          WIFI_BACKUP_TASK_CORE);
-#endif  // HAS_BACKUP_WIFI
+	xTaskCreatePinnedToCore(wifi_backup_task_code,
+							"wifi_backup_task",
+							WIFI_BACKUP_TASK_STACK_SIZE,
+							nullptr,
+							WIFI_BACKUP_TASK_PRIORITY,
+							&wifi_backup_task_handler,
+							WIFI_BACKUP_TASK_CORE);
+#endif // HAS_BACKUP_WIFI
 
-  Log.infoln("MAC Address:        '" + wifi_get_mac_address() + "'");
-  Log.infoln("SSID:               '" + String(WIFI_SSID) + "'");
-  // Connecto to WiFi network
-  if (!wifi_connect(WIFI_SSID, WIFI_PWD)) {
-    Log.fatalln("something went wrong connecting to WiFi");
-    reboot_board();
-  }
-  Log.infoln("Device IP:          '" + wifi_get_ip() + "'");
+	Log.infoln("MAC Address:        '" + wifi_get_mac_address() + "'");
+	Log.infoln("SSID:               '" + String(WIFI_SSID) + "'");
+	// Connecto to WiFi network
+	if (!wifi_connect(WIFI_SSID, WIFI_PWD)) {
+		Log.fatalln("something went wrong connecting to WiFi");
+		reboot_board();
+	}
+	Log.infoln("Device IP:          '" + wifi_get_ip() + "'");
 
 #ifdef HAS_TELNET
-  // Init telnet
-  if (telnet_init()) {
-    xTaskCreatePinnedToCore(telnet_task_code,
-                            "telnet_task",
-                            TELNET_TASK_STACK_SIZE,
-                            nullptr,
-                            TELNET_TASK_PRIORITY,
-                            &telnet_task_handler,
-                            TELNET_TASK_CORE);
-  } else {
-    Log.errorln("something went wrong initializing Telnet");
-  }
-#endif  // HAS_TELNET
+	// Init telnet
+	if (telnet_init()) {
+		xTaskCreatePinnedToCore(telnet_task_code,
+								"telnet_task",
+								TELNET_TASK_STACK_SIZE,
+								nullptr,
+								TELNET_TASK_PRIORITY,
+								&telnet_task_handler,
+								TELNET_TASK_CORE);
+	} else {
+		Log.errorln("something went wrong initializing Telnet");
+	}
+#endif // HAS_TELNET
 
 #ifdef HAS_INFLUXDB
-  // Init InfluxDB
-  Log.infoln("InfluxDB url:       '" INFLUXDB_URL "'");
-  Log.infoln("InfluxDB org:       '" INFLUXDB_ORG "'");
-  Log.infoln("InfluxDB bucket:    '" INFLUXDB_BUCKET "'");
+	// Init InfluxDB
+	Log.infoln("InfluxDB url:       '" INFLUXDB_URL "'");
+	Log.infoln("InfluxDB org:       '" INFLUXDB_ORG "'");
+	Log.infoln("InfluxDB bucket:    '" INFLUXDB_BUCKET "'");
 
-  if (!influxdb_init()) {
-    Log.fatalln("something went wrong initializing InfluxDB");
-  }
-#endif  // HAS_INFLUXDB
+	if (!influxdb_init()) {
+		Log.fatalln("something went wrong initializing InfluxDB");
+	}
+#endif // HAS_INFLUXDB
 
-  // Init available sensors
-  init_all_available_sensors();
+	// Init available sensors
+	init_all_available_sensors();
 
-  xTaskCreatePinnedToCore(measure_and_send_task_code,
-                          "measure_task",
-                          MEASURE_TASK_STACK_SIZE,
-                          nullptr,
-                          MEASURE_TASK_PRIORITY,
-                          &measure_task_handler,
-                          MEASURE_TASK_CORE);
+	xTaskCreatePinnedToCore(measure_and_send_task_code,
+							"measure_task",
+							MEASURE_TASK_STACK_SIZE,
+							nullptr,
+							MEASURE_TASK_PRIORITY,
+							&measure_task_handler,
+							MEASURE_TASK_CORE);
 }
 
 void loop() {}

--- a/src/board_preference.cpp
+++ b/src/board_preference.cpp
@@ -1,15 +1,13 @@
 #include "board_preference.h"
+
+#include <EEPROM.h>
+#include <assert.h>
+
 #include "log.h"
 
-#include <assert.h>
-#include <EEPROM.h>
-
-#define _PREF_HAS_SENSOR_BIT(bytes, idx) \
-  (((bytes >> (uint16_t)idx)) & (uint16_t)0x01)
-#define _PREF_SET_SENSOR_BIT(bytes, idx) \
-  bytes |= ((uint16_t)0x01 << (uint16_t)idx)
-#define _PREF_UNSET_SENSOR_BIT(bytes, idx) \
-  bytes &= ~((uint16_t)0x01 << (uint16_t)idx)
+#define _PREF_HAS_SENSOR_BIT(bytes, idx)   (((bytes >> (uint16_t)idx)) & (uint16_t)0x01)
+#define _PREF_SET_SENSOR_BIT(bytes, idx)   bytes |= ((uint16_t)0x01 << (uint16_t)idx)
+#define _PREF_UNSET_SENSOR_BIT(bytes, idx) bytes &= ~((uint16_t)0x01 << (uint16_t)idx)
 
 BoardPreference Preference;
 
@@ -20,7 +18,8 @@ bool BoardPreference::init() {
     return false;
   }
   if (!read_preferences()) {
-    Log.debugln("BoardPreference::init: EEPROM memory is malformed and will be restored to default state");
+    Log.debugln("BoardPreference::init: EEPROM memory is malformed and will be "
+                "restored to default state");
     return clear();
   }
   return true;
@@ -29,11 +28,11 @@ bool BoardPreference::init() {
 bool BoardPreference::clear() {
   Log.traceln("BoardPreference::clear: restoring preferences to default state");
   _available_sensors_bytes = 0x0;
-  _board_host_name = "";
-  _board_location = "";
-  _board_room = "";
-  _spoofed_mac_addr = "";
-  _temperature_offset = 0;
+  _board_host_name         = "";
+  _board_location          = "";
+  _board_room              = "";
+  _spoofed_mac_addr        = "";
+  _temperature_offset      = 0;
   return write_preferences();
 }
 
@@ -74,7 +73,8 @@ String BoardPreference::available_sensors_to_String() {
 }
 
 bool BoardPreference::read_preferences() {
-  Log.traceln("BoardPreference::read_preferences: reading board preferences form EEPROM");
+  Log.traceln("BoardPreference::read_preferences: reading board preferences "
+              "form EEPROM");
 
   int addr = 0;
   // Read header magic number and perform sanity check
@@ -84,30 +84,26 @@ bool BoardPreference::read_preferences() {
   if (magic != PREFERENCES_HEADER_MAGIC) {
     Log.errorln("BoardPreference::read_preferences: error reading preferences; "
                 "expecting header magic number: 0x"
-                + String(PREFERENCES_HEADER_MAGIC, HEX)
-                + " but got: 0x" + String(magic, HEX));
+                + String(PREFERENCES_HEADER_MAGIC, HEX) + " but got: 0x" + String(magic, HEX));
     return false;
   }
   // Read other preferences
   _available_sensors_bytes = EEPROM.readUShort(addr);
   addr += sizeof(uint16_t);
-  Log.traceln("BoardPreference::read_preferences: _available_sensors_bytes: 0x" + String(_available_sensors_bytes, HEX));
+  Log.traceln("BoardPreference::read_preferences: _available_sensors_bytes: 0x"
+              + String(_available_sensors_bytes, HEX));
   _board_host_name = EEPROM.readString(addr);
   addr += _board_host_name.length() + 1;
-  Log.traceln("BoardPreference::read_preferences: _board_host_name: '"
-              + _board_host_name + "'");
+  Log.traceln("BoardPreference::read_preferences: _board_host_name: '" + _board_host_name + "'");
   _board_location = EEPROM.readString(addr);
   addr += _board_location.length() + 1;
-  Log.traceln("BoardPreference::read_preferences: _board_location: '"
-              + _board_location + "'");
+  Log.traceln("BoardPreference::read_preferences: _board_location: '" + _board_location + "'");
   _board_room = EEPROM.readString(addr);
   addr += _board_room.length() + 1;
-  Log.traceln("BoardPreference::read_preferences: _board_room: '"
-              + _board_room + "'");
+  Log.traceln("BoardPreference::read_preferences: _board_room: '" + _board_room + "'");
   _spoofed_mac_addr = EEPROM.readString(addr);
   addr += _spoofed_mac_addr.length() + 1;
-  Log.traceln("BoardPreference::read_preferences: _spoofed_mac_addr: '"
-              + _spoofed_mac_addr + "'");
+  Log.traceln("BoardPreference::read_preferences: _spoofed_mac_addr: '" + _spoofed_mac_addr + "'");
   _temperature_offset = EEPROM.readByte(addr);
   addr += sizeof(uint8_t);
   Log.traceln("BoardPreference::read_preferences: _temperature_offset: "
@@ -117,12 +113,13 @@ bool BoardPreference::read_preferences() {
 }
 
 bool BoardPreference::write_preferences() {
-  Log.traceln("BoardPreference::write_preferences: writing board preferences to EEPROM");
-  Log.traceln("BoardPreference::write_preferences: _available_sensors_bytes: '0x" + String(_available_sensors_bytes, HEX) + "', "
-              + "_board_host_name: '" + _board_host_name + "', "
-              + "_board_location: '" + _board_location + "', "
-              + "_board_room: '" + _board_room + "'"
-              + "_spoofed_mac_addr: '" + _spoofed_mac_addr + "'");
+  Log.traceln("BoardPreference::write_preferences: writing board preferences "
+              "to EEPROM");
+  Log.traceln("BoardPreference::write_preferences: _available_sensors_bytes: '0x"
+              + String(_available_sensors_bytes, HEX) + "', " + "_board_host_name: '"
+              + _board_host_name + "', " + "_board_location: '" + _board_location + "', "
+              + "_board_room: '" + _board_room + "'" + "_spoofed_mac_addr: '" + _spoofed_mac_addr
+              + "'");
 
   int addr = 0;
   // Write header magic number
@@ -143,7 +140,8 @@ bool BoardPreference::write_preferences() {
   addr += sizeof(uint8_t);
 
   if (!EEPROM.commit()) {
-    Log.errorln("BoardPreference::write_preferences: error writing preferences to EEPROM");
+    Log.errorln("BoardPreference::write_preferences: error writing preferences "
+                "to EEPROM");
     return false;
   }
   return true;

--- a/src/board_preference.h
+++ b/src/board_preference.h
@@ -1,17 +1,17 @@
 #ifndef BOARD_PREFERENCE_H
 #define BOARD_PREFERENCE_H
 
-#include "sensor/sensor_type.h"
-
 #include <Arduino.h>
+
+#include "sensor/sensor_type.h"
 
 // Header magic number for the preferences.
 #define PREFERENCES_HEADER_MAGIC 0x494F5420
 
 // Default values for preferences.
 #define DEFAULT_BOARD_HOST_NAME "default_host"
-#define DEFAULT_BOARD_LOCATION "default_location"
-#define DEFAULT_BOARD_ROOM "default_room"
+#define DEFAULT_BOARD_LOCATION  "default_location"
+#define DEFAULT_BOARD_ROOM      "default_room"
 
 /*
  * Class representing board's global preferences.
@@ -20,7 +20,7 @@
  * EEPROM and are read and write each time they are updated.
  */
 class BoardPreference {
-public:
+  public:
   /*
    * Init the global preferences.
    */
@@ -69,9 +69,7 @@ public:
    * Returns the board's host name.
    */
   String get_board_host_name() const {
-    return _board_host_name.isEmpty()
-             ? DEFAULT_BOARD_HOST_NAME
-             : _board_host_name;
+    return _board_host_name.isEmpty() ? DEFAULT_BOARD_HOST_NAME : _board_host_name;
   }
 
   /*
@@ -89,9 +87,7 @@ public:
    * Returns the board's location.
    */
   String get_board_location() const {
-    return _board_location.isEmpty()
-             ? DEFAULT_BOARD_LOCATION
-             : _board_location;
+    return _board_location.isEmpty() ? DEFAULT_BOARD_LOCATION : _board_location;
   }
 
   /*
@@ -108,11 +104,7 @@ public:
   /*
    * Returns the bord's room.
    */
-  String get_board_room() const {
-    return _board_room.isEmpty()
-             ? DEFAULT_BOARD_ROOM
-             : _board_room;
-  }
+  String get_board_room() const { return _board_room.isEmpty() ? DEFAULT_BOARD_ROOM : _board_room; }
 
   /*
    * Set the board's room.
@@ -129,9 +121,7 @@ public:
    * Returns true if the board has enabled
    * MAC address spoofing, false otherwise.
    */
-  bool has_spoofed_mac() const {
-    return !_spoofed_mac_addr.isEmpty();
-  }
+  bool has_spoofed_mac() const { return !_spoofed_mac_addr.isEmpty(); }
 
   /*
    * Returns the MAC address used for spoofing as
@@ -141,9 +131,7 @@ public:
    * In case MAC address spoofing is not enabled
    * this function returns an empry String.
    */
-  String get_spoofed_mac() const {
-    return _spoofed_mac_addr;
-  }
+  String get_spoofed_mac() const { return _spoofed_mac_addr; }
 
   /*
    * Set the MAC address used for spoofing.
@@ -160,16 +148,14 @@ public:
     return write_preferences();
   }
 
-  int8_t get_temperature_offset() const {
-    return _temperature_offset;
-  }
+  int8_t get_temperature_offset() const { return _temperature_offset; }
 
   bool set_temperatue_offset(int offset) {
     _temperature_offset = (uint8_t)offset;
     return write_preferences();
   }
 
-private:
+  private:
   /*
    * Available sensors are represented by 2 bytes (uint16_t)
    * so we can have a total of 16 different sensors.
@@ -178,11 +164,11 @@ private:
    * and if the bit is set it means that the sensor is present.
    */
   uint16_t _available_sensors_bytes = 0;
-  String _board_host_name;
-  String _board_location;
-  String _board_room;
-  String _spoofed_mac_addr;
-  uint8_t _temperature_offset = 0;
+  String   _board_host_name;
+  String   _board_location;
+  String   _board_room;
+  String   _spoofed_mac_addr;
+  uint8_t  _temperature_offset = 0;
 
   bool read_preferences();
   bool write_preferences();
@@ -193,4 +179,4 @@ private:
  */
 extern BoardPreference Preference;
 
-#endif  // BOARD_PREFERENCE_H
+#endif // BOARD_PREFERENCE_H

--- a/src/common.h
+++ b/src/common.h
@@ -2,16 +2,16 @@
 #define COMMON_H
 
 /*
- * Common header included throughout the project 
+ * Common header included throughout the project
  * to easily manage all the includes.
  */
 
-#include "config.h"
-#include "utils.h"
-#include "log.h"
-#include "board_preference.h"
-#include "version.h"
-
 #include <Arduino.h>
 
-#endif  // COMMON_H
+#include "board_preference.h"
+#include "config.h"
+#include "log.h"
+#include "utils.h"
+#include "version.h"
+
+#endif // COMMON_H

--- a/src/config.h
+++ b/src/config.h
@@ -1,12 +1,13 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#include "../arduino_secrets.h"
 #include <assert.h>
+
+#include "../arduino_secrets.h"
 
 /*
  * Global configuration header.
- * 
+ *
  * Here we put all the configurations for the
  * various elements of the project.
  */
@@ -24,11 +25,11 @@
 
 // WiFi Settings
 #define WIFI_SSID SECRET_WIFI_SSID
-#define WIFI_PWD SECRET_WIFI_PWD
+#define WIFI_PWD  SECRET_WIFI_PWD
 
 #define HAS_BACKUP_WIFI
-#define WIFI_BACKUP_SSID SECRET_WIFI_BACKUP_SSID
-#define WIFI_BACKUP_PWD SECRET_WIFI_BACKUP_PWD
+#define WIFI_BACKUP_SSID       SECRET_WIFI_BACKUP_SSID
+#define WIFI_BACKUP_PWD        SECRET_WIFI_BACKUP_PWD
 #define WIFI_BACKUP_JUMPER_PIN 26
 
 // Delay in milliseconds after each sensor reading loop.
@@ -62,13 +63,13 @@ static_assert(SENSOR_AVG_WINDOW > 2, "SENSOR_AVG_WINDOW must be > 2");
 
 // InfluxDB settings.
 #define HAS_INFLUXDB
-#define INFLUXDB_URL SECRET_INFLUXDB_URL
-#define INFLUXDB_ORG SECRET_INFLUXDB_ORG
-#define INFLUXDB_BUCKET SECRET_INFLUXDB_BUCKET
-#define INFLUXDB_TOKEN SECRET_INFLUXDB_TOKEN
+#define INFLUXDB_URL        SECRET_INFLUXDB_URL
+#define INFLUXDB_ORG        SECRET_INFLUXDB_ORG
+#define INFLUXDB_BUCKET     SECRET_INFLUXDB_BUCKET
+#define INFLUXDB_TOKEN      SECRET_INFLUXDB_TOKEN
 #define INFLUXDB_POINT_NAME SECRET_INFLUXDB_POINT_NAME
 
 // Telnet settings.
 #define HAS_TELNET
 
-#endif  // CONFIG_H
+#endif // CONFIG_H

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -4,26 +4,19 @@
 Logger Log(LogLevel::TRACE);
 #else
 Logger Log(LogLevel::INFO);
-#endif  // IS_DEBUG
+#endif // IS_DEBUG
 
-static const String log_level_string[] = {
-  "[TRACE]  ",
-  "[DEBUG]  ",
-  "[INFO]   ",
-  "[ERROR]  ",
-  "[FATAL]  ",
-  "[SILENT] "
-};
+static const String log_level_string[]
+    = {"[TRACE]  ", "[DEBUG]  ", "[INFO]   ", "[ERROR]  ", "[FATAL]  ", "[SILENT] "};
 
-Logger::Logger(LogLevel level)
-  : _level(level),
-    _cr_done(true) {}
+Logger::Logger(LogLevel level) : _level(level), _cr_done(true) {}
 
 void Logger::init(int speed) {
   LOGGER_SERIAL.begin(speed);
   delay(200);
   LOGGER_SERIAL.println();
 }
+
 void Logger::trace(const String &s) {
   print(LogLevel::TRACE, s);
 }
@@ -85,11 +78,13 @@ void Logger::fatalln(const String &s) {
 }
 
 void Logger::print(LogLevel level, const String &s) {
-  if (level < _level)
+  if (level < _level) {
     return;
+  }
 
-  if (_cr_done)
+  if (_cr_done) {
     LOGGER_SERIAL.print(log_level_string[level]);
+  }
   LOGGER_SERIAL.print(s);
   _cr_done = false;
 }

--- a/src/log.h
+++ b/src/log.h
@@ -6,49 +6,47 @@
 #include "config.h"
 
 /*
+ * Enum representing the log level.
+ */
+enum LogLevel {
+  TRACE,
+  DEBUG,
+  INFO,
+  ERROR,
+  FATAL,
+  SILENT
+};
+
+/*
  * Class implementing a logger.
  */
 class Logger {
   public:
-  /*
-   * Enum representing the log level.
-   */
-  enum LogLevel {
-    TRACE,
-    DEBUG,
-    INFO,
-    ERROR,
-    FATAL,
-    SILENT
-  };
-
   Logger(LogLevel level);
 
   void init(int speed = BAUD_RATE);
 
-  inline void trace(const String &s) { print(LogLevel::TRACE, s); }
+  void trace(const String &s);
+  void debug(const String &s);
+  void info(const String &s);
+  void error(const String &s);
+  void fatal(const String &s);
 
-  inline void debug(const String &s) { print(LogLevel::DEBUG, s); }
+  void traceln();
+  void debugln();
+  void infoln();
+  void errorln();
+  void fatalln();
 
-  inline void info(const String &s) { print(LogLevel::INFO, s); }
-
-  inline void error(const String &s) { print(LogLevel::ERROR, s); }
-
-  inline void fatal(const String &s) { print(LogLevel::FATAL, s); }
-
-  inline void traceln(const String &s = "") { println(LogLevel::TRACE, s); }
-
-  inline void debugln(const String &s = "") { println(LogLevel::DEBUG, s); }
-
-  inline void infoln(const String &s = "") { println(LogLevel::INFO, s); }
-
-  inline void errorln(const String &s = "") { println(LogLevel::ERROR, s); }
-
-  inline void fatalln(const String &s = "") { println(LogLevel::FATAL, s); }
+  void traceln(const String &s);
+  void debugln(const String &s);
+  void infoln(const String &s);
+  void errorln(const String &s);
+  void fatalln(const String &s);
 
   private:
   LogLevel _level;
-  bool     _cr_done = true;
+  bool     _cr_done;
 
   void print(LogLevel level, const String &s);
   void println(LogLevel level, const String &s);

--- a/src/log.h
+++ b/src/log.h
@@ -1,52 +1,54 @@
 #ifndef LOG_H
 #define LOG_H
 
-#include "config.h"
-
 #include <Arduino.h>
 
-/*
- * Enum representing the log level.
- */
-enum LogLevel {
-  TRACE,
-  DEBUG,
-  INFO,
-  ERROR,
-  FATAL,
-  SILENT
-};
+#include "config.h"
 
 /*
  * Class implementing a logger.
  */
 class Logger {
-public:
+  public:
+  /*
+   * Enum representing the log level.
+   */
+  enum LogLevel {
+    TRACE,
+    DEBUG,
+    INFO,
+    ERROR,
+    FATAL,
+    SILENT
+  };
+
   Logger(LogLevel level);
 
   void init(int speed = BAUD_RATE);
 
-  void trace(const String &s);
-  void debug(const String &s);
-  void info(const String &s);
-  void error(const String &s);
-  void fatal(const String &s);
+  inline void trace(const String &s) { print(LogLevel::TRACE, s); }
 
-  void traceln();
-  void debugln();
-  void infoln();
-  void errorln();
-  void fatalln();
+  inline void debug(const String &s) { print(LogLevel::DEBUG, s); }
 
-  void traceln(const String &s);
-  void debugln(const String &s);
-  void infoln(const String &s);
-  void errorln(const String &s);
-  void fatalln(const String &s);
+  inline void info(const String &s) { print(LogLevel::INFO, s); }
 
-private:
+  inline void error(const String &s) { print(LogLevel::ERROR, s); }
+
+  inline void fatal(const String &s) { print(LogLevel::FATAL, s); }
+
+  inline void traceln(const String &s = "") { println(LogLevel::TRACE, s); }
+
+  inline void debugln(const String &s = "") { println(LogLevel::DEBUG, s); }
+
+  inline void infoln(const String &s = "") { println(LogLevel::INFO, s); }
+
+  inline void errorln(const String &s = "") { println(LogLevel::ERROR, s); }
+
+  inline void fatalln(const String &s = "") { println(LogLevel::FATAL, s); }
+
+  private:
   LogLevel _level;
-  bool _cr_done;
+  bool     _cr_done = true;
 
   void print(LogLevel level, const String &s);
   void println(LogLevel level, const String &s);
@@ -55,4 +57,4 @@ private:
 // Global Logger instance.
 extern Logger Log;
 
-#endif  // LOG_H
+#endif // LOG_H

--- a/src/network/influxdb.cpp
+++ b/src/network/influxdb.cpp
@@ -1,15 +1,16 @@
 #include "influxdb.h"
-#include "../common.h"
-#include "../sensor/DHT11_sensor.h"
-#include "../sensor/SGP30_sensor.h"
-#include "../sensor/SPS30_sensor.h"
-#include "../sensor/MHZ19_sensor.h"
 
 #include <InfluxDbClient.h>
 #include <InfluxDbCloud.h>
 
+#include "../common.h"
+#include "../sensor/DHT11_sensor.h"
+#include "../sensor/MHZ19_sensor.h"
+#include "../sensor/SGP30_sensor.h"
+#include "../sensor/SPS30_sensor.h"
+
 static InfluxDBClient influxdb_client;
-static Point influxdb_point(INFLUXDB_POINT_NAME);
+static Point          influxdb_point(INFLUXDB_POINT_NAME);
 
 bool influxdb_init() {
   Log.debugln("influxdb_init: init influxDB with following parameters: "
@@ -17,20 +18,16 @@ bool influxdb_init() {
               "org: '" INFLUXDB_ORG "', "
               "bucket: '" INFLUXDB_BUCKET "'");
 
-  influxdb_client.setConnectionParams(INFLUXDB_URL,
-                                      INFLUXDB_ORG,
-                                      INFLUXDB_BUCKET,
-                                      INFLUXDB_TOKEN,
-                                      InfluxDbCloud2CACert);
+  influxdb_client.setConnectionParams(
+      INFLUXDB_URL, INFLUXDB_ORG, INFLUXDB_BUCKET, INFLUXDB_TOKEN, InfluxDbCloud2CACert);
 
   influxdb_point.addTag("host", Preference.get_board_host_name());
   influxdb_point.addTag("location", Preference.get_board_location());
   influxdb_point.addTag("room", Preference.get_board_room());
 
-  Log.traceln("influxdb_init: added tags: host: '"
-              + Preference.get_board_host_name()
-              + "', location: '" + Preference.get_board_location()
-              + "', room: '" + Preference.get_board_room() + "'");
+  Log.traceln("influxdb_init: added tags: host: '" + Preference.get_board_host_name()
+              + "', location: '" + Preference.get_board_location() + "', room: '"
+              + Preference.get_board_room() + "'");
 
   if (!influxdb_client.validateConnection()) {
     Log.errorln("influxdb_init: connection error: " + influxdb_client.getLastErrorMessage());

--- a/src/network/influxdb.h
+++ b/src/network/influxdb.h
@@ -2,16 +2,16 @@
 #define INFLUXDB_H
 
 // Constants Field Names.
-#define INFLUXDB_FIELD_DHT11_TEMPERATURE "dht11_temperature"
-#define INFLUXDB_FIELD_DHT11_HUMIDITY "dht11_humidity"
-#define INFLUXDB_FIELD_SGP30_TVOC "sgp30_TVOC"
-#define INFLUXDB_FIELD_SGP30_ECO2 "sgp30_eCO2"
-#define INFLUXDB_FIELD_SPS30_MC_1p0 "sps30_mc_1p0"
-#define INFLUXDB_FIELD_SPS30_MC_2p5 "sps30_mc_2p5"
-#define INFLUXDB_FIELD_SPS30_MC_4p0 "sps30_mc_4p0"
-#define INFLUXDB_FIELD_SPS30_MC_10p0 "sps30_mc_10p0"
+#define INFLUXDB_FIELD_DHT11_TEMPERATURE   "dht11_temperature"
+#define INFLUXDB_FIELD_DHT11_HUMIDITY      "dht11_humidity"
+#define INFLUXDB_FIELD_SGP30_TVOC          "sgp30_TVOC"
+#define INFLUXDB_FIELD_SGP30_ECO2          "sgp30_eCO2"
+#define INFLUXDB_FIELD_SPS30_MC_1p0        "sps30_mc_1p0"
+#define INFLUXDB_FIELD_SPS30_MC_2p5        "sps30_mc_2p5"
+#define INFLUXDB_FIELD_SPS30_MC_4p0        "sps30_mc_4p0"
+#define INFLUXDB_FIELD_SPS30_MC_10p0       "sps30_mc_10p0"
 #define INFLUXDB_FIELD_SPS30_PARTICLE_SIZE "sps30_particle_size"
-#define INFLUXDB_FIELD_MHZ19_CO2 "mhz19_co2"
+#define INFLUXDB_FIELD_MHZ19_CO2           "mhz19_co2"
 
 /*
  * Init a new connection with InfluxDB server.
@@ -23,4 +23,4 @@ bool influxdb_init();
  */
 bool influxdb_write_sensors();
 
-#endif  // INFLUXDB_H
+#endif // INFLUXDB_H

--- a/src/network/telnet.cpp
+++ b/src/network/telnet.cpp
@@ -1,8 +1,9 @@
 #include "telnet.h"
-#include "wifi.h"
-#include "../sensor_helper.h"
 
 #include <ESPTelnet.h>
+
+#include "../sensor_helper.h"
+#include "wifi.h"
 
 static String string_divide_by(String *s, char delim) {
   size_t i = 0;
@@ -10,15 +11,16 @@ static String string_divide_by(String *s, char delim) {
     i++;
   }
   String result = s->substring(0, i);
-  *s = s->substring(i);
+  *s            = s->substring(i);
   return result;
 }
 
 typedef void (*cmd_on_run)(String cmd);
+
 struct TelnetCommand {
-  String name;
+  String     name;
   cmd_on_run run;
-  String help;
+  String     help;
 };
 
 static ESPTelnet telnet;
@@ -40,28 +42,26 @@ static void cmd_quit(String);
 static void cmd_help(String);
 
 static const TelnetCommand commands[] = {
-  { "info", cmd_info, "retrieve the values from all available sensors" },
-  { "sensors", cmd_sensors_list, "list the available sensors" },
-  { "sensors-add", cmd_sensors_add, "mark a sensor as available" },
-  { "sensors-rm", cmd_sensors_rm, "mark a sensor as no longer available" },
-  { "board-host", cmd_board_host, "get or set board's host name" },
-  { "board-location", cmd_board_location, "get or set board's location" },
-  { "board-room", cmd_board_room, "get or set board's room" },
-  { "mac", cmd_mac_address, "get or set MAC address (off to use default)" },
-  { "tmp-offset", cmd_temp_offset, "get or set offset subtracted by each temperature value" },
-  { "uptime", cmd_uptime, "get the time elapsed since the board's boot" },
-  { "ping", cmd_ping, "ping the board" },
-  { "reboot", cmd_reboot, "reboot the board" },
-  { "version", cmd_version, "show current firmware version" },
-  { "quit", cmd_quit, "exit" },
-  { "help", cmd_help, "show this help message" },
+    {"info",           cmd_info,           "retrieve the values from all available sensors"        },
+    {"sensors",        cmd_sensors_list,   "list the available sensors"                            },
+    {"sensors-add",    cmd_sensors_add,    "mark a sensor as available"                            },
+    {"sensors-rm",     cmd_sensors_rm,     "mark a sensor as no longer available"                  },
+    {"board-host",     cmd_board_host,     "get or set board's host name"                          },
+    {"board-location", cmd_board_location, "get or set board's location"                           },
+    {"board-room",     cmd_board_room,     "get or set board's room"                               },
+    {"mac",            cmd_mac_address,    "get or set MAC address (off to use default)"           },
+    {"tmp-offset",     cmd_temp_offset,    "get or set offset subtracted by each temperature value"},
+    {"uptime",         cmd_uptime,         "get the time elapsed since the board's boot"           },
+    {"ping",           cmd_ping,           "ping the board"                                        },
+    {"reboot",         cmd_reboot,         "reboot the board"                                      },
+    {"version",        cmd_version,        "show current firmware version"                         },
+    {"quit",           cmd_quit,           "exit"                                                  },
+    {"help",           cmd_help,           "show this help message"                                },
 };
 
 static void cmd_info(String _) {
   telnet.println("Values from available sensors:");
-  print_available_sensors_info([](String line) {
-    telnet.println(line);
-  });
+  print_available_sensors_info([](String line) { telnet.println(line); });
 }
 
 static void cmd_sensors_list(String _) {
@@ -160,8 +160,7 @@ static void cmd_mac_address(String mac_addr) {
     return;
   }
 
-  Log.traceln("cmd_mac_address: want to set MAC address to: '"
-              + mac_addr + "'");
+  Log.traceln("cmd_mac_address: want to set MAC address to: '" + mac_addr + "'");
   if (!Preference.set_spoofed_mac(mac_addr)) {
     telnet.println("cannot set MAC address");
   }
@@ -283,8 +282,7 @@ bool telnet_init(int port) {
 void telnet_task_code(void *args) {
   TickType_t last_loop_time = xTaskGetTickCount();
   for (;;) {
-    xTaskDelayUntil(&last_loop_time,
-                    pdMS_TO_TICKS(TELNET_LOOP_DELAY_MS));
+    xTaskDelayUntil(&last_loop_time, pdMS_TO_TICKS(TELNET_LOOP_DELAY_MS));
 
     telnet.loop();
   }

--- a/src/network/telnet.h
+++ b/src/network/telnet.h
@@ -8,14 +8,14 @@
 
 // Telent Task config.
 #define TELNET_TASK_STACK_SIZE 10240
-#define TELNET_TASK_PRIORITY 5
-#define TELNET_TASK_CORE tskNO_AFFINITY
+#define TELNET_TASK_PRIORITY   5
+#define TELNET_TASK_CORE       tskNO_AFFINITY
 
 #define TELNET_LOOP_DELAY_MS 200
 
 // Error message for sensors command unknown.
-#define SENSORS_CMD_ERROR_STR(cmd) \
-  "expecting a sensor name after " cmd "command. " \
+#define SENSORS_CMD_ERROR_STR(cmd)                      \
+  "expecting a sensor name after " cmd "command. "      \
   "If you wanto to list all available sensors use the " \
   "sensors command instead or use help to view all commands."
 
@@ -30,4 +30,4 @@ bool telnet_init(int port = TELNET_PORT);
  */
 void telnet_task_code(void *args);
 
-#endif  // TELNET_H
+#endif // TELNET_H

--- a/src/network/wifi.cpp
+++ b/src/network/wifi.cpp
@@ -1,12 +1,12 @@
 #include "wifi.h"
 
-#include <esp_wifi.h>
+#include <IPAddress.h>
 #include <WiFi.h>
-#include "IPAddress.h"
+#include <esp_wifi.h>
 
 #ifdef HAS_BACKUP_WIFI
 static int old_backup_state = HIGH;
-#endif  // HAS_BACKUP_WIFI
+#endif // HAS_BACKUP_WIFI
 
 // TODO: Make function set_mac_address publicly available.
 //  Currently we call WiFi.mode(WIFI_STA) inside wifi_connect, so the WiFi
@@ -17,13 +17,18 @@ static int old_backup_state = HIGH;
 //  network, but, in case we implement the access piont we can let the user
 //  change the MAC.
 static void set_mac_address(String mac) {
-  int mac_val[6];
+  int     mac_val[6];
   uint8_t mac_bytes[6];
 
   // Parse MAC address string to bytes
-  int sz = sscanf(mac.c_str(), "%x:%x:%x:%x:%x:%x%*c",
-                  &mac_val[0], &mac_val[1], &mac_val[2],
-                  &mac_val[3], &mac_val[4], &mac_val[5]);
+  int sz = sscanf(mac.c_str(),
+                  "%x:%x:%x:%x:%x:%x%*c",
+                  &mac_val[0],
+                  &mac_val[1],
+                  &mac_val[2],
+                  &mac_val[3],
+                  &mac_val[4],
+                  &mac_val[5]);
   if (sz != 6) {
     Log.errorln("set_mac_address: invalid MAC address: '" + mac + "'");
     return;
@@ -34,20 +39,15 @@ static void set_mac_address(String mac) {
   }
   esp_err_t err = esp_wifi_set_mac(WIFI_IF_STA, mac_bytes);
   if (err == ESP_OK) {
-    Log.debugln("set_mac_address: new MAC address: "
-                + wifi_get_mac_address());
+    Log.debugln("set_mac_address: new MAC address: " + wifi_get_mac_address());
   } else {
-    Log.traceln("set_mac_address: error setting MAC: "
-                + String(esp_err_to_name(err)));
+    Log.traceln("set_mac_address: error setting MAC: " + String(esp_err_to_name(err)));
   }
 }
 
-bool wifi_connect(const char *ssid, const char *pwd,
-                  int max_retry, int pause) {
-  Log.traceln("wifi_connect: connecting to SSID: '" + String(ssid)
-              + "' with pwd: '" + String(pwd)
-              + "' attempts: " + String(max_retry)
-              + " delay: " + String(pause));
+bool wifi_connect(const char *ssid, const char *pwd, int max_retry, int pause) {
+  Log.traceln("wifi_connect: connecting to SSID: '" + String(ssid) + "' with pwd: '" + String(pwd)
+              + "' attempts: " + String(max_retry) + " delay: " + String(pause));
 
   LED_ON(SIGNAL_LED_PIN);
 
@@ -119,4 +119,4 @@ void wifi_backup_task_code(void *args) {
     old_backup_state = backup_state;
   }
 }
-#endif  //HAS_BACKUP_WIFI
+#endif // HAS_BACKUP_WIFI

--- a/src/network/wifi.h
+++ b/src/network/wifi.h
@@ -11,11 +11,11 @@
 // Backup WiFi task config.
 #ifdef HAS_BACKUP_WIFI
 // TODO: Reduce stack size used by wifi backup task
-#define WIFI_BACKUP_TASK_STACK_SIZE 4096
-#define WIFI_BACKUP_TASK_PRIORITY 5
-#define WIFI_BACKUP_TASK_CORE tskNO_AFFINITY
-#define WIFI_BACKUP_TASK_DELAY_MS 1000
-#endif  // HAS_BACKUP_WIFI
+#  define WIFI_BACKUP_TASK_STACK_SIZE 4096
+#  define WIFI_BACKUP_TASK_PRIORITY   5
+#  define WIFI_BACKUP_TASK_CORE       tskNO_AFFINITY
+#  define WIFI_BACKUP_TASK_DELAY_MS   1000
+#endif // HAS_BACKUP_WIFI
 /*
  * Returns true if the device is connected to a WiFi network,
  * false otherwise.
@@ -28,9 +28,10 @@ bool wifi_is_connected();
  * Return true if the connection is successful,
  * false in case of errors.
  */
-bool wifi_connect(const char *ssid, const char *pwd,
-                  int max_retry = WIFI_MAX_CONN_RETRY,
-                  int pause = WIFI_RETRY_PAUSE_MS);
+bool wifi_connect(const char *ssid,
+                  const char *pwd,
+                  int         max_retry = WIFI_MAX_CONN_RETRY,
+                  int         pause     = WIFI_RETRY_PAUSE_MS);
 
 /*
  * Returns the current IP address as String if the device
@@ -62,6 +63,6 @@ String wifi_get_mac_address();
  */
 #ifdef HAS_BACKUP_WIFI
 void wifi_backup_task_code(void *args);
-#endif  // HAS_BACKUP_WIFI
+#endif // HAS_BACKUP_WIFI
 
-#endif  // WIFI_H
+#endif // WIFI_H

--- a/src/sensor/DHT11_sensor.cpp
+++ b/src/sensor/DHT11_sensor.cpp
@@ -1,12 +1,10 @@
 #include "DHT11_sensor.h"
+
 #include "../common.h"
 
 DHT11_Sensor DHT11Sensor;
 
-DHT11_Sensor::DHT11_Sensor()
-  : _dht(DHT11_PIN, DHT11),
-    _temperature(0.0),
-    _humidity(0.0) {}
+DHT11_Sensor::DHT11_Sensor() : _dht(DHT11_PIN, DHT11), _temperature(0.0), _humidity(0.0) {}
 
 bool DHT11_Sensor::on_init() {
   _dht.begin();
@@ -16,16 +14,11 @@ bool DHT11_Sensor::on_init() {
 }
 
 bool DHT11_Sensor::on_measure() {
-  float currentT = 0.0,
-        currentH = 0.0,
-        maxT = 0.0,
-        minT = 0.0,
-        maxH = 0.0,
-        minH = 0.0;
+  float currentT = 0.0, currentH = 0.0, maxT = 0.0, minT = 0.0, maxH = 0.0, minH = 0.0;
 
   Log.traceln("DHT11_Sensor::measure: reading sensor values");
   _temperature = 0.0;
-  _humidity = 0.0;
+  _humidity    = 0.0;
   for (int i = 0; i < SENSOR_AVG_WINDOW; ++i) {
     currentT = _dht.readTemperature();
     currentH = _dht.readHumidity();
@@ -57,15 +50,14 @@ bool DHT11_Sensor::on_measure() {
 
   // Remove temperature offset from data
   Log.traceln("DHT11_Sensor::measure: using offset of "
-              + String(Preference.get_temperature_offset())
-              + " for real temperature of "
+              + String(Preference.get_temperature_offset()) + " for real temperature of "
               + String(_temperature));
   _temperature -= Preference.get_temperature_offset();
 
 #ifdef PRINT_SENSORS_ON_READ
   Log.debugln("DHT11 temperature: " + String(_temperature));
   Log.debugln("DHT11 humidity: " + String(_humidity));
-#endif  // PRINT_SENSORS_ON_READ
+#endif // PRINT_SENSORS_ON_READ
 
   return true;
 }

--- a/src/sensor/DHT11_sensor.h
+++ b/src/sensor/DHT11_sensor.h
@@ -1,15 +1,15 @@
 #ifndef DHT11_SENSOR_H
 #define DHT11_SENSOR_H
 
-#include "abstract_sensor.h"
-
 #include <DHT.h>
+
+#include "abstract_sensor.h"
 
 // Delay in milliseconds for the sensor init process.
 #define DHT11_INIT_DELAY_MS 300
 
 class DHT11_Sensor : public AbstractSensor {
-public:
+  public:
   DHT11_Sensor();
 
   bool on_init() override;
@@ -18,19 +18,15 @@ public:
   /*
    * Return the last measured temperature.
    */
-  float get_temperature() const {
-    return _temperature;
-  };
+  float get_temperature() const { return _temperature; };
 
   /*
    * Return the last measured humidity.
    */
-  float get_humidity() const {
-    return _humidity;
-  }
+  float get_humidity() const { return _humidity; }
 
-private:
-  DHT _dht;
+  private:
+  DHT   _dht;
   float _temperature;
   float _humidity;
 };
@@ -40,4 +36,4 @@ private:
  */
 extern DHT11_Sensor DHT11Sensor;
 
-#endif  // DHT11_SENSOR_H
+#endif // DHT11_SENSOR_H

--- a/src/sensor/MHZ19_sensor.cpp
+++ b/src/sensor/MHZ19_sensor.cpp
@@ -1,4 +1,5 @@
 #include "MHZ19_sensor.h"
+
 #include "../common.h"
 
 MHZ19_Sensor MHZ19Sensor;
@@ -13,9 +14,7 @@ bool MHZ19_Sensor::on_init() {
 }
 
 bool MHZ19_Sensor::on_measure() {
-  int currentCo2 = 0,
-      minCo2 = 0,
-      maxCo2 = 0;
+  int currentCo2 = 0, minCo2 = 0, maxCo2 = 0;
 
   Log.traceln("MHZ19_Sensor::measure: reading sensor values");
   for (int i = 0; i < SENSOR_AVG_WINDOW; ++i) {
@@ -37,7 +36,7 @@ bool MHZ19_Sensor::on_measure() {
 
 #ifdef PRINT_SENSORS_ON_READ
   Log.debugln("MHZ19 Co2: " + String(_co2));
-#endif  // PRINT_SENSORS_ON_READ
+#endif // PRINT_SENSORS_ON_READ
 
   return true;
 }

--- a/src/sensor/MHZ19_sensor.h
+++ b/src/sensor/MHZ19_sensor.h
@@ -1,28 +1,26 @@
 #ifndef MHZ19_SENSOR_H
 #define MHZ19_SENSOR_H
 
-#include "abstract_sensor.h"
-
 #include <MHZCO2.h>
+
+#include "abstract_sensor.h"
 
 // Delay in milliseconds for the sensor init process.
 #define MHZ19_INIT_DELAY_MS 300
 
 class MHZ19_Sensor : public AbstractSensor {
-public:
+  public:
   bool on_init() override;
   bool on_measure() override;
 
   /*
    * Returns the last measured CO2.
    */
-  int get_co2() const {
-    return _co2;
-  }
+  int get_co2() const { return _co2; }
 
-private:
+  private:
   MHZ19B _mhz;
-  int _co2 = 0;
+  int    _co2 = 0;
 };
 
 /*
@@ -30,4 +28,4 @@ private:
  */
 extern MHZ19_Sensor MHZ19Sensor;
 
-#endif  // MHZ19_SENSOR_H
+#endif // MHZ19_SENSOR_H

--- a/src/sensor/SGP30_sensor.cpp
+++ b/src/sensor/SGP30_sensor.cpp
@@ -1,8 +1,9 @@
 #include "SGP30_sensor.h"
+
+#include <Adafruit_SGP30.h>
+
 #include "../common.h"
 #include "DHT11_sensor.h"
-
-#include "Adafruit_SGP30.h"
 
 SGP30_Sensor SGP30Sensor;
 
@@ -17,19 +18,18 @@ bool SGP30_Sensor::on_init() {
 }
 
 bool SGP30_Sensor::on_measure() {
-  uint16_t currentTvoc = 0.0,
-           currentEco2 = 0.0,
-           minTvoc = 0.0,
-           maxTvoc = 0.0,
-           minEco2 = 0.0,
+  uint16_t currentTvoc = 0.0, currentEco2 = 0.0, minTvoc = 0.0, maxTvoc = 0.0, minEco2 = 0.0,
            maxEco2 = 0.0;
 
   Log.traceln("SGP30_Sensor::measure: reading sensor values");
   if (DHT11Sensor.get_temperature() > 0) {
-    Log.traceln("SGP30_Sensor::measure: compute absolute humidity with real temperature and humidity");
-    _sgp.setHumidity(get_absolute_humidity(DHT11Sensor.get_temperature(), DHT11Sensor.get_humidity()));
+    Log.traceln(
+        "SGP30_Sensor::measure: compute absolute humidity with real temperature and humidity");
+    _sgp.setHumidity(
+        get_absolute_humidity(DHT11Sensor.get_temperature(), DHT11Sensor.get_humidity()));
   } else {
-    Log.traceln("SGP30_Sensor::measure: compute absolute humidity with default temperature and humidity");
+    Log.traceln("SGP30_Sensor::measure: compute absolute humidity with default temperature and "
+                "humidity");
     _sgp.setHumidity(get_absolute_humidity(22.1, 45.2));
   }
 
@@ -66,13 +66,16 @@ bool SGP30_Sensor::on_measure() {
 #ifdef PRINT_SENSORS_ON_READ
   Log.debugln("SGP30 TVOC: " + String(_tvoc));
   Log.debugln("SGP30 eCO2: " + String(_eco2));
-#endif  // PRINT_SENSORS_ON_READ
+#endif // PRINT_SENSORS_ON_READ
 
   return true;
 }
 
 uint32_t SGP30_Sensor::get_absolute_humidity(float temperature, float humidity) {
-  const float absoluteHumidity = 216.7f * ((humidity / 100.0f) * 6.112f * exp((17.62f * temperature) / (243.12f + temperature)) / (273.15f + temperature));
+  const float absoluteHumidity
+      = 216.7f
+        * ((humidity / 100.0f) * 6.112f * exp((17.62f * temperature) / (243.12f + temperature))
+           / (273.15f + temperature));
   const uint32_t absoluteHumidityScaled = static_cast<uint32_t>(1000.0f * absoluteHumidity);
   return absoluteHumidityScaled;
 }

--- a/src/sensor/SGP30_sensor.h
+++ b/src/sensor/SGP30_sensor.h
@@ -1,9 +1,9 @@
 #ifndef SGP30_SENSOR_H
 #define SGP30_SENSOR_H
 
-#include "abstract_sensor.h"
-
 #include <Adafruit_SGP30.h>
+
+#include "abstract_sensor.h"
 
 // Delay in milliseconds for the init process.
 #define SGP30_INIT_DELAY_MS 300
@@ -11,7 +11,7 @@
 #define SGP30_MEASURE_DELAY_MS 1000
 
 class SGP30_Sensor : public AbstractSensor {
-public:
+  public:
   bool on_init() override;
   bool on_measure() override;
 
@@ -19,26 +19,22 @@ public:
    * Return the last measured Total Volatile Organic
    * Compounds in ppb.
    */
-  int get_TVOC() const {
-    return _tvoc;
-  }
+  int get_TVOC() const { return _tvoc; }
 
   /*
    * Return the last measured equivalent CO2 in ppm.
    */
-  int get_eCO2() const {
-    return _eco2;
-  }
+  int get_eCO2() const { return _eco2; }
 
-private:
+  private:
   /*
    * Return the absolute humidity from given temperature and humidity.
    */
   static uint32_t get_absolute_humidity(float temperature, float humidity);
 
   Adafruit_SGP30 _sgp;
-  uint16_t _tvoc = 0.0;
-  uint16_t _eco2 = 0.0;
+  uint16_t       _tvoc = 0.0;
+  uint16_t       _eco2 = 0.0;
 };
 
 /*
@@ -46,4 +42,4 @@ private:
  */
 extern SGP30_Sensor SGP30Sensor;
 
-#endif  // SGP30_SENSOR_H
+#endif // SGP30_SENSOR_H

--- a/src/sensor/SPS30_sensor.cpp
+++ b/src/sensor/SPS30_sensor.cpp
@@ -1,7 +1,8 @@
 #include "SPS30_sensor.h"
-#include "../common.h"
 
 #include <sps30.h>
+
+#include "../common.h"
 
 SPS30_Sensor SPS30Sensor;
 
@@ -23,7 +24,8 @@ bool SPS30_Sensor::on_init() {
     return false;
   }
 
-  Log.traceln("SPS30_Sensor::init: set fan auto-cleaning days to " + String(SPS30_FAN_AUTO_CLEAN_DAYS));
+  Log.traceln("SPS30_Sensor::init: set fan auto-cleaning days to "
+              + String(SPS30_FAN_AUTO_CLEAN_DAYS));
   ret = sps30_set_fan_auto_cleaning_interval_days(SPS30_FAN_AUTO_CLEAN_DAYS);
   if (ret) {
     Log.errorln("SPS30_Sensor::init: error setting auto-cleaning interval: " + String(ret));
@@ -43,7 +45,7 @@ bool SPS30_Sensor::on_init() {
 }
 
 bool SPS30_Sensor::on_measure() {
-  int16_t ret;
+  int16_t  ret;
   uint16_t data_ready;
 
   Log.traceln("SPS30_Sensor::measure: reading sensor values");
@@ -68,7 +70,7 @@ bool SPS30_Sensor::on_measure() {
   Log.debugln("SPS30 PM 2.5: " + String(_sps_meas.mc_2p5));
   Log.debugln("SPS30 PM 4.0: " + String(_sps_meas.mc_4p0));
   Log.debugln("SPS30 PM 10.0: " + String(_sps_meas.mc_10p0));
-#endif  // PRINT_SENSORS_ON_READ
+#endif // PRINT_SENSORS_ON_READ
 
   return true;
 }

--- a/src/sensor/SPS30_sensor.h
+++ b/src/sensor/SPS30_sensor.h
@@ -1,86 +1,68 @@
 #ifndef SPS30_SENSOR_H
 #define SPS30_SENSOR_H
 
-#include "abstract_sensor.h"
-
 #include <sps30.h>
 
-#define SPS30_MAX_PROBE_RETRY 10
+#include "abstract_sensor.h"
+
+#define SPS30_MAX_PROBE_RETRY      10
 #define SPS30_PROBE_RETRY_DELAY_MS 500
-#define SPS30_FAN_AUTO_CLEAN_DAYS 4
+#define SPS30_FAN_AUTO_CLEAN_DAYS  4
 
 // Delay in milliseconds for the sensor init process.
 #define SPS30_INIT_DELAY_MS 300
 
 class SPS30_Sensor : public AbstractSensor {
-public:
+  public:
   bool on_init() override;
   bool on_measure() override;
 
   /*
    * Returns the last measured MC 1.0
    */
-  float get_mc_1p0() const {
-    return _sps_meas.mc_1p0;
-  }
+  float get_mc_1p0() const { return _sps_meas.mc_1p0; }
 
   /*
    * Returns the last measured MC 2.5
    */
-  float get_mc_2p5() const {
-    return _sps_meas.mc_2p5;
-  }
+  float get_mc_2p5() const { return _sps_meas.mc_2p5; }
 
   /*
    * Returns the last measured MC 4.0
    */
-  float get_mc_4p0() const {
-    return _sps_meas.mc_4p0;
-  }
+  float get_mc_4p0() const { return _sps_meas.mc_4p0; }
 
   /*
    * Returns the last measured MC 10.0
    */
-  float get_mc_10p0() const {
-    return _sps_meas.mc_10p0;
-  }
+  float get_mc_10p0() const { return _sps_meas.mc_10p0; }
 
   /*
    * Returns the last measured NC 1.0
    */
-  float get_nc_1p0() const {
-    return _sps_meas.nc_1p0;
-  }
+  float get_nc_1p0() const { return _sps_meas.nc_1p0; }
 
   /*
    * Returns the last measured NC 2.5
    */
-  float get_nc_2p5() const {
-    return _sps_meas.nc_2p5;
-  }
+  float get_nc_2p5() const { return _sps_meas.nc_2p5; }
 
   /*
    * Returns the last measured NC 4.0
    */
-  float get_nc_4p0() const {
-    return _sps_meas.nc_4p0;
-  }
+  float get_nc_4p0() const { return _sps_meas.nc_4p0; }
 
   /*
    * Returns the last measured NC 10.0
    */
-  float get_nc_10p0() const {
-    return _sps_meas.nc_10p0;
-  }
+  float get_nc_10p0() const { return _sps_meas.nc_10p0; }
 
   /*
    * Returns the last measured typical particle size.
    */
-  float get_particle_size() const {
-    return _sps_meas.typical_particle_size;
-  }
+  float get_particle_size() const { return _sps_meas.typical_particle_size; }
 
-private:
+  private:
   struct sps30_measurement _sps_meas;
 };
 
@@ -89,4 +71,4 @@ private:
  */
 extern SPS30_Sensor SPS30Sensor;
 
-#endif  // SPS30_SENSOR_H
+#endif // SPS30_SENSOR_H

--- a/src/sensor/abstract_sensor.cpp
+++ b/src/sensor/abstract_sensor.cpp
@@ -6,7 +6,7 @@ bool AbstractSensor::init() {
   }
 
   bool init_res = on_init();
-  p_is_init = init_res;
+  p_is_init     = init_res;
   return init_res;
 }
 

--- a/src/sensor/abstract_sensor.h
+++ b/src/sensor/abstract_sensor.h
@@ -9,7 +9,7 @@
  * sensor and measure his data.
  */
 class AbstractSensor {
-public:
+  public:
   /*
    * Initialize the sensor.
    *
@@ -26,7 +26,7 @@ public:
    */
   bool measure();
 
-protected:
+  protected:
   /*
    * Variable stating if the sensor is already initialized.
    */
@@ -45,4 +45,4 @@ protected:
   virtual bool on_measure() = 0;
 };
 
-#endif  // ABSTRACT_SENSOR_H
+#endif // ABSTRACT_SENSOR_H

--- a/src/sensor/sensor_type.cpp
+++ b/src/sensor/sensor_type.cpp
@@ -2,17 +2,17 @@
 
 String SensorType_to_String(SensorType t) {
   switch (t) {
-    case SENSOR_DHT11:
-      return "SENSOR_DHT11";
-    case SENSOR_SGP30:
-      return "SENSOR_SGP30";
-    case SENSOR_MHZ19:
-      return "SENSOR_MHZ19";
-    case SENSOR_SPS30:
-      return "SENSOR_SPS30";
-    default:
-      assert(false && "SensorType_to_String: unreachable");
-      exit(1);
+  case SENSOR_DHT11:
+    return "SENSOR_DHT11";
+  case SENSOR_SGP30:
+    return "SENSOR_SGP30";
+  case SENSOR_MHZ19:
+    return "SENSOR_MHZ19";
+  case SENSOR_SPS30:
+    return "SENSOR_SPS30";
+  default:
+    assert(false && "SensorType_to_String: unreachable");
+    exit(1);
   }
 }
 

--- a/src/sensor/sensor_type.h
+++ b/src/sensor/sensor_type.h
@@ -2,7 +2,8 @@
 #define SENSOR_TYPE_H
 
 #include <assert.h>
-#include <Arduino.h>
+
+#include "../common.h"
 
 /*
  * Enum representing the type of
@@ -16,6 +17,7 @@ enum SensorType {
 
   COUNT_SENSORS
 };
+
 static_assert(COUNT_SENSORS == 4,
               "The number of Sensor Types have changed. "
               "You probably have added or removed a sensor. "
@@ -31,4 +33,4 @@ String SensorType_to_String(SensorType t);
  */
 bool SensorType_by_name(String s, SensorType *t);
 
-#endif  // SENSOR_TYPE_H
+#endif // SENSOR_TYPE_H

--- a/src/sensor/sensor_type.h
+++ b/src/sensor/sensor_type.h
@@ -1,9 +1,8 @@
 #ifndef SENSOR_TYPE_H
 #define SENSOR_TYPE_H
 
+#include <Arduino.h>
 #include <assert.h>
-
-#include "../common.h"
 
 /*
  * Enum representing the type of

--- a/src/sensor_helper.cpp
+++ b/src/sensor_helper.cpp
@@ -1,4 +1,5 @@
 #include "sensor_helper.h"
+
 #include "network/influxdb.h"
 
 bool init_all_available_sensors() {
@@ -7,8 +8,7 @@ bool init_all_available_sensors() {
     SensorTypeToImplPair p = type_to_sensor_map[i];
     if (Preference.has_sensor(p.type)) {
       if (p.sensor == nullptr || !p.sensor->init()) {
-        Log.errorln("something went wrong initializing "
-                    + SensorType_to_String(p.type));
+        Log.errorln("something went wrong initializing " + SensorType_to_String(p.type));
         has_errors = true;
       }
     }
@@ -22,8 +22,7 @@ bool measure_all_available_sensors() {
     SensorTypeToImplPair p = type_to_sensor_map[i];
     if (Preference.has_sensor(p.type)) {
       if (p.sensor == nullptr || !p.sensor->measure()) {
-        Log.errorln("something went wrong measuring "
-                    + SensorType_to_String(p.type));
+        Log.errorln("something went wrong measuring " + SensorType_to_String(p.type));
         has_errors = true;
       }
     }
@@ -55,9 +54,7 @@ void print_available_sensors_info(void (*print)(String)) {
 void measure_and_send_task_code(void *args) {
   TickType_t last_measure_time = xTaskGetTickCount();
   for (;;) {
-    xTaskDelayUntil(
-      &last_measure_time,
-      pdMS_TO_TICKS(SENSOR_READING_DELAY_MS));
+    xTaskDelayUntil(&last_measure_time, pdMS_TO_TICKS(SENSOR_READING_DELAY_MS));
 
     measure_all_available_sensors();
 #ifdef HAS_INFLUXDB
@@ -66,6 +63,6 @@ void measure_and_send_task_code(void *args) {
       Log.fatalln("something went wrong writing to InfluxDB");
       reboot_board();
     }
-#endif  // HAS_INFLUXDB
+#endif // HAS_INFLUXDB
   }
 }

--- a/src/sensor_helper.h
+++ b/src/sensor_helper.h
@@ -1,35 +1,35 @@
 #ifndef SENSOR_HELPER_H
 #define SENSOR_HELPER_H
 
+#include <assert.h>
+
 #include "common.h"
-#include "sensor/sensor_type.h"
-#include "sensor/abstract_sensor.h"
 #include "sensor/DHT11_sensor.h"
+#include "sensor/MHZ19_sensor.h"
 #include "sensor/SGP30_sensor.h"
 #include "sensor/SPS30_sensor.h"
-#include "sensor/MHZ19_sensor.h"
-
-#include <assert.h>
+#include "sensor/abstract_sensor.h"
+#include "sensor/sensor_type.h"
 
 // Measure task config.
 #define MEASURE_TASK_STACK_SIZE 4096
-#define MEASURE_TASK_PRIORITY 8
-#define MEASURE_TASK_CORE tskNO_AFFINITY
+#define MEASURE_TASK_PRIORITY   8
+#define MEASURE_TASK_CORE       tskNO_AFFINITY
 
 /*
  * Struct that maps SensorType to objects
  * implementing AbstractSensor.
  */
 struct SensorTypeToImplPair {
-  SensorType type;
+  SensorType      type;
   AbstractSensor *sensor;
 };
 
 static const SensorTypeToImplPair type_to_sensor_map[] = {
-  { SensorType::SENSOR_DHT11, &DHT11Sensor },
-  { SensorType::SENSOR_SGP30, &SGP30Sensor },
-  { SensorType::SENSOR_MHZ19, &MHZ19Sensor },
-  { SensorType::SENSOR_SPS30, &SPS30Sensor },
+    {SensorType::SENSOR_DHT11, &DHT11Sensor},
+    {SensorType::SENSOR_SGP30, &SGP30Sensor},
+    {SensorType::SENSOR_MHZ19, &MHZ19Sensor},
+    {SensorType::SENSOR_SPS30, &SPS30Sensor},
 };
 static_assert(size_of_array(type_to_sensor_map) == SensorType::COUNT_SENSORS,
               "The number of elements of type_to_sensor_map have changed. "
@@ -70,4 +70,4 @@ void print_available_sensors_info(void (*print)(String));
  */
 void measure_and_send_task_code(void *args);
 
-#endif  // SENSOR_HELPER_H
+#endif // SENSOR_HELPER_H

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,7 +1,8 @@
 #include "utils.h"
-#include "log.h"
 
 #include <esp_timer.h>
+
+#include "log.h"
 
 void reboot_board(int wait_ms) {
   Log.debugln("rebooting the board after " + String(wait_ms) + "ms");
@@ -15,11 +16,9 @@ String board_uptime() {
 
   int64_t seconds = micro / 1000000;
   int64_t minutes = seconds / 60;
-  int64_t hours = minutes / 60;
-  int64_t days = hours / 24;
+  int64_t hours   = minutes / 60;
+  int64_t days    = hours / 24;
 
-  return String(days) + "days, "
-         + String(hours % 24) + "hours, "
-         + String(minutes % 60) + "minutes, "
-         + String(seconds % 60) + "seconds";
+  return String(days) + "days, " + String(hours % 24) + "hours, " + String(minutes % 60)
+         + "minutes, " + String(seconds % 60) + "seconds";
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,14 +1,14 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-#include "config.h"
-
 #include <Arduino.h>
+
+#include "config.h"
 
 /*
  * Compute the size of an array at compile time.
  */
-template<class A, size_t N>
+template <class A, size_t N>
 constexpr size_t size_of_array(A (&)[N]) {
   return N;
 }
@@ -19,18 +19,18 @@ constexpr size_t size_of_array(A (&)[N]) {
 /*
  * Macro to turn on a LED.
  */
-#define LED_ON(led) \
-  do { \
-    pinMode(led, OUTPUT); \
+#define LED_ON(led)          \
+  do {                       \
+    pinMode(led, OUTPUT);    \
     digitalWrite(led, HIGH); \
   } while (0)
 
 /*
  * Macro to turn off a LED.
  */
-#define LED_OFF(led) \
-  do { \
-    pinMode(led, OUTPUT); \
+#define LED_OFF(led)        \
+  do {                      \
+    pinMode(led, OUTPUT);   \
     digitalWrite(led, LOW); \
   } while (0)
 
@@ -51,4 +51,4 @@ void reboot_board(int wait_ms = BOARD_REBOOT_DELAY_MS);
  */
 String board_uptime();
 
-#endif  // UTILS_H
+#endif // UTILS_H

--- a/src/version.h
+++ b/src/version.h
@@ -1,11 +1,11 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define VERSION_MAJOR "0"
-#define VERSION_MINOR "0"
+#define VERSION_MAJOR    "0"
+#define VERSION_MINOR    "0"
 #define VERSION_REVISION "1"
 
 // String representing the current firmware version.
 #define VERSION VERSION_MAJOR "." VERSION_MINOR "." VERSION_REVISION
 
-#endif  //VERSION_H
+#endif // VERSION_H


### PR DESCRIPTION
This PR uses the tool `clang-format` with a custom `.clang-format` configuration file to automatically format the entire code base (all files `.h`, `.cpp`, `.ino`).
When merged this PR will close #19 