### PR TITLE
Preference: Verify memory consistency with checksum

### DIFF
--- a/src/board_preference.cpp
+++ b/src/board_preference.cpp
@@ -87,6 +87,11 @@ bool BoardPreference::read_preferences() {
                 + String(PREFERENCES_HEADER_MAGIC, HEX) + " but got: 0x" + String(magic, HEX));
     return false;
   }
+
+  // Read stored checksum bytes
+  uint16_t old_checksum = EEPROM.readUShort(addr);
+  addr += sizeof(uint16_t);
+
   // Read other preferences
   _available_sensors_bytes = EEPROM.readUShort(addr);
   addr += sizeof(uint16_t);
@@ -109,6 +114,14 @@ bool BoardPreference::read_preferences() {
   Log.debugln("BoardPreference::read_preferences: _temperature_offset: "
               + String(_temperature_offset));
 
+  // Compute checksum of the parameter just read and check
+  // if it's equal to the one stored in memory
+  uint16_t new_checksum = checksum();
+  if (old_checksum != new_checksum) {
+    Log.errorln("BoardPreference::read_preferences: checksum is not equal to the one stored ("
+                + String(old_checksum) + "!=" + String(new_checksum) + ")");
+    return false;
+  }
   return true;
 }
 
@@ -127,6 +140,9 @@ bool BoardPreference::write_preferences() {
   // Write header magic number
   EEPROM.writeUInt(addr, PREFERENCES_HEADER_MAGIC);
   addr += sizeof(uint32_t);
+  // Write checksum
+  EEPROM.writeUShort(addr, checksum());
+  addr += sizeof(uint16_t);
   // Write other preferences
   EEPROM.writeUShort(addr, _available_sensors_bytes);
   addr += sizeof(uint16_t);
@@ -147,4 +163,50 @@ bool BoardPreference::write_preferences() {
     return false;
   }
   return true;
+}
+
+void BoardPreference::create_checksum_prefs_buffer() {
+  _checksum_buffer_sz = 0;
+  _checksum_buffer_sz += sizeof(_available_sensors_bytes);
+  _checksum_buffer_sz += _board_host_name.length();
+  _checksum_buffer_sz += _board_location.length();
+  _checksum_buffer_sz += _board_room.length();
+  _checksum_buffer_sz += _spoofed_mac_addr.length();
+  _checksum_buffer_sz += sizeof(_temperature_offset);
+
+  if (_checksum_buffer != nullptr) {
+    free(_checksum_buffer);
+  }
+  _checksum_buffer = (uint8_t *)malloc(_checksum_buffer_sz);
+  Log.traceln("BoardPreference::create_checksum_prefs_buffer: create checksum buffer with size "
+              + String(_checksum_buffer_sz));
+
+  size_t address = 0;
+  memcpy((_checksum_buffer + address), &_available_sensors_bytes, sizeof(_available_sensors_bytes));
+  address += sizeof(_available_sensors_bytes);
+  memcpy((_checksum_buffer + address), _board_host_name.c_str(), _board_host_name.length());
+  address += _board_host_name.length();
+  memcpy((_checksum_buffer + address), _board_location.c_str(), _board_location.length());
+  address += _board_location.length();
+  memcpy((_checksum_buffer + address), _board_room.c_str(), _board_room.length());
+  address += _board_room.length();
+  memcpy((_checksum_buffer + address), _spoofed_mac_addr.c_str(), _spoofed_mac_addr.length());
+  address += _spoofed_mac_addr.length();
+  memcpy((_checksum_buffer + address), &_temperature_offset, sizeof(_temperature_offset));
+  address += sizeof(_temperature_offset);
+}
+
+uint16_t BoardPreference::checksum() {
+  uint8_t a = 1, b = 0;
+
+  // Compute the checksum from the preferences as buffer
+  create_checksum_prefs_buffer();
+  for (int i = 0; i < _checksum_buffer_sz; i++) {
+    a = (a + _checksum_buffer[i]) % UINT8_MAX;
+    b = (a + b) % UINT8_MAX;
+  }
+
+  uint16_t cs = ((b << 8) | a);
+  Log.traceln("BoardPreference::checksum: computed checksum '" + String(cs) + "'");
+  return cs;
 }

--- a/src/board_preference.cpp
+++ b/src/board_preference.cpp
@@ -26,7 +26,7 @@ bool BoardPreference::init() {
 }
 
 bool BoardPreference::clear() {
-  Log.traceln("BoardPreference::clear: restoring preferences to default state");
+  Log.debugln("BoardPreference::clear: restoring preferences to default state");
   _available_sensors_bytes = 0x0;
   _board_host_name         = "";
   _board_location          = "";
@@ -80,7 +80,7 @@ bool BoardPreference::read_preferences() {
   // Read header magic number and perform sanity check
   uint32_t magic = EEPROM.readUInt(addr);
   addr += sizeof(uint32_t);
-  Log.debugln("BoardPreference::read_preferences: header magic number: 0x" + String(magic, HEX));
+  Log.traceln("BoardPreference::read_preferences: header magic number: 0x" + String(magic, HEX));
   if (magic != PREFERENCES_HEADER_MAGIC) {
     Log.errorln("BoardPreference::read_preferences: error reading preferences; "
                 "expecting header magic number: 0x"
@@ -90,36 +90,38 @@ bool BoardPreference::read_preferences() {
   // Read other preferences
   _available_sensors_bytes = EEPROM.readUShort(addr);
   addr += sizeof(uint16_t);
-  Log.traceln("BoardPreference::read_preferences: _available_sensors_bytes: 0x"
+  Log.debugln("BoardPreference::read_preferences: _available_sensors_bytes: 0x"
               + String(_available_sensors_bytes, HEX));
   _board_host_name = EEPROM.readString(addr);
   addr += _board_host_name.length() + 1;
-  Log.traceln("BoardPreference::read_preferences: _board_host_name: '" + _board_host_name + "'");
+  Log.debugln("BoardPreference::read_preferences: _board_host_name: '" + _board_host_name + "'");
   _board_location = EEPROM.readString(addr);
   addr += _board_location.length() + 1;
-  Log.traceln("BoardPreference::read_preferences: _board_location: '" + _board_location + "'");
+  Log.debugln("BoardPreference::read_preferences: _board_location: '" + _board_location + "'");
   _board_room = EEPROM.readString(addr);
   addr += _board_room.length() + 1;
-  Log.traceln("BoardPreference::read_preferences: _board_room: '" + _board_room + "'");
+  Log.debugln("BoardPreference::read_preferences: _board_room: '" + _board_room + "'");
   _spoofed_mac_addr = EEPROM.readString(addr);
   addr += _spoofed_mac_addr.length() + 1;
-  Log.traceln("BoardPreference::read_preferences: _spoofed_mac_addr: '" + _spoofed_mac_addr + "'");
+  Log.debugln("BoardPreference::read_preferences: _spoofed_mac_addr: '" + _spoofed_mac_addr + "'");
   _temperature_offset = EEPROM.readByte(addr);
   addr += sizeof(uint8_t);
-  Log.traceln("BoardPreference::read_preferences: _temperature_offset: "
+  Log.debugln("BoardPreference::read_preferences: _temperature_offset: "
               + String(_temperature_offset));
 
   return true;
 }
 
 bool BoardPreference::write_preferences() {
-  Log.traceln("BoardPreference::write_preferences: writing board preferences "
+  Log.debugln("BoardPreference::write_preferences: writing board preferences "
               "to EEPROM");
-  Log.traceln("BoardPreference::write_preferences: _available_sensors_bytes: '0x"
-              + String(_available_sensors_bytes, HEX) + "', " + "_board_host_name: '"
-              + _board_host_name + "', " + "_board_location: '" + _board_location + "', "
-              + "_board_room: '" + _board_room + "'" + "_spoofed_mac_addr: '" + _spoofed_mac_addr
-              + "'");
+  Log.trace("BoardPreference::write_preferences: ");
+  Log.trace("_available_sensors_bytes: '0x" + String(_available_sensors_bytes, HEX) + "', ");
+  Log.trace("_board_host_name: '" + _board_host_name + "', ");
+  Log.trace("_board_location: '" + _board_location + "', ");
+  Log.trace("_board_room: '" + _board_room + "'");
+  Log.trace("_spoofed_mac_addr: '" + _spoofed_mac_addr + "'");
+  Log.traceln("_temperature_offset: '" + String(_temperature_offset) + "'");
 
   int addr = 0;
   // Write header magic number

--- a/src/board_preference.cpp
+++ b/src/board_preference.cpp
@@ -72,6 +72,31 @@ String BoardPreference::available_sensors_to_String() {
   return ret;
 }
 
+bool BoardPreference::set_board_host_name(String name) {
+  _board_host_name = name;
+  return write_preferences();
+}
+
+bool BoardPreference::set_board_location(String location) {
+  _board_location = location;
+  return write_preferences();
+}
+
+bool BoardPreference::set_board_room(String room) {
+  _board_room = room;
+  return write_preferences();
+}
+
+bool BoardPreference::set_spoofed_mac(String mac) {
+  _spoofed_mac_addr = mac;
+  return write_preferences();
+}
+
+bool BoardPreference::set_temperature_offset(int offset) {
+  _temperature_offset = (uint8_t)offset;
+  return write_preferences();
+}
+
 bool BoardPreference::read_preferences() {
   Log.traceln("BoardPreference::read_preferences: reading board preferences "
               "form EEPROM");

--- a/src/board_preference.h
+++ b/src/board_preference.h
@@ -170,8 +170,24 @@ class BoardPreference {
   String   _spoofed_mac_addr;
   uint8_t  _temperature_offset = 0;
 
+  // Checksum internal buffer.
+  uint8_t *_checksum_buffer    = nullptr;
+  size_t   _checksum_buffer_sz = 0;
+
   bool read_preferences();
   bool write_preferences();
+
+  /*
+   * Compute the checksum from all the preferences
+   * stored inside the board's EEPROM.
+   *
+   * This checksum function implements a 16bit version
+   * of the Adler-32 algorithm.
+   *
+   * Returns the computed checksum as a 16bit unsigned int.
+   */
+  uint16_t checksum();
+  void     create_checksum_prefs_buffer();
 };
 
 /*

--- a/src/board_preference.h
+++ b/src/board_preference.h
@@ -30,7 +30,7 @@ class BoardPreference {
    * Clear all the preferences stored inside the board
    * restoring them to their default values.
    *
-   * Returns flase if the change cannot be applied
+   * Returns false if the change cannot be applied
    * and leaves the values unchanged.
    */
   bool clear();
@@ -52,7 +52,7 @@ class BoardPreference {
   /*
    * Mark the given sensor as available.
    *
-   * Returns flase if the change cannot be applied
+   * Returns false if the change cannot be applied
    * and leaves the values unchanged.
    */
   bool add_sensor(SensorType s);
@@ -60,7 +60,7 @@ class BoardPreference {
   /*
    * Mark the given sensor as no longer available.
    *
-   * Returns flase if the change cannot be applied
+   * Returns false if the change cannot be applied
    * and leaves the values unchanged.
    */
   bool remove_sensor(SensorType s);
@@ -75,13 +75,10 @@ class BoardPreference {
   /*
    * Set the board's host name.
    *
-   * Returns flase if the change cannot be applied
+   * Returns false if the change cannot be applied
    * and leaves the values unchanged.
    */
-  bool set_board_host_name(String name) {
-    _board_host_name = name;
-    return write_preferences();
-  }
+  bool set_board_host_name(String name);
 
   /*
    * Returns the board's location.
@@ -93,29 +90,23 @@ class BoardPreference {
   /*
    * Set the board's location.
    *
-   * Returns flase if the change cannot be applied
+   * Returns false if the change cannot be applied
    * and leaves the values unchanged.
    */
-  bool set_board_location(String location) {
-    _board_location = location;
-    return write_preferences();
-  }
+  bool set_board_location(String location);
 
   /*
-   * Returns the bord's room.
+   * Returns the board's room.
    */
   String get_board_room() const { return _board_room.isEmpty() ? DEFAULT_BOARD_ROOM : _board_room; }
 
   /*
    * Set the board's room.
    *
-   * Returns flase if the change cannot be applied
+   * Returns false if the change cannot be applied
    * and leaves the values unchanged.
    */
-  bool set_board_room(String room) {
-    _board_room = room;
-    return write_preferences();
-  }
+  bool set_board_room(String room);
 
   /*
    * Returns true if the board has enabled
@@ -129,7 +120,7 @@ class BoardPreference {
    * by column.
    *
    * In case MAC address spoofing is not enabled
-   * this function returns an empry String.
+   * this function returns an empty String.
    */
   String get_spoofed_mac() const { return _spoofed_mac_addr; }
 
@@ -143,17 +134,20 @@ class BoardPreference {
    * spoofing will be disabled and the connection
    * will use the default one.
    */
-  bool set_spoofed_mac(String mac) {
-    _spoofed_mac_addr = mac;
-    return write_preferences();
-  }
+  bool set_spoofed_mac(String mac);
 
+  /*
+   * Return the temperature offset.
+   */
   int8_t get_temperature_offset() const { return _temperature_offset; }
 
-  bool set_temperatue_offset(int offset) {
-    _temperature_offset = (uint8_t)offset;
-    return write_preferences();
-  }
+  /*
+   * Set the temperature offset.
+   *
+   * Returns false is the change cannot be applied
+   * and leaves the values unchanged.
+   */
+  bool set_temperature_offset(int offset);
 
   private:
   /*

--- a/src/network/telnet.cpp
+++ b/src/network/telnet.cpp
@@ -174,7 +174,7 @@ static void cmd_temp_offset(String temp_str) {
   } else {
     Log.traceln("cmd_temp_offset: wants to set temperature offset");
     int temp_offset = (int)temp_str.toInt();
-    if (!Preference.set_temperatue_offset(temp_offset)) {
+    if (!Preference.set_temperature_offset(temp_offset)) {
       telnet.println("error setting temperature offset");
     }
   }


### PR DESCRIPTION
In this PR we implement the ability to check for memory corruption of the preferences stored inside the board's EEPROM.

To do so we use a checksum function that is a variation of the Adler32 algorithm, but using only 16bits. This algorithm is easy to perform and takes less memory, so it's suited for ESP devices.

When merged this PR will close #20 